### PR TITLE
chore: update Agentgateway v1.4.1 CRD schemas

### DIFF
--- a/agentgateway.dev/agentgatewaybackend_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaybackend_v1alpha1.json
@@ -35,8 +35,7 @@
             "host",
             "port"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "ai": {
           "description": "LLM backend.",
@@ -59,8 +58,7 @@
                               "type": "string"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "azure": {
                           "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
@@ -108,8 +106,7 @@
                               "message": "projectName is required when resourceType is Foundry",
                               "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "azureopenai": {
                           "description": "Azure OpenAI provider settings.",
@@ -142,8 +139,7 @@
                               "message": "deploymentName is required for this apiVersion",
                               "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "bedrock": {
                           "description": "Bedrock provider settings.",
@@ -168,8 +164,7 @@
                                 "identifier",
                                 "version"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "model": {
                               "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
@@ -186,8 +181,7 @@
                               "type": "string"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "custom": {
                           "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
@@ -233,8 +227,7 @@
                                   "message": "Must have port for Service reference",
                                   "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "formats": {
                               "description": "Provider-native API formats this provider supports.",
@@ -270,8 +263,7 @@
                                     "message": "path must start with /",
                                     "rule": "!has(self.path) || self.path.startsWith('/')"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "maxItems": 6,
                               "minItems": 1,
@@ -297,8 +289,7 @@
                               "message": "custom provider backendRef may target only Service or InferencePool",
                               "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "gemini": {
                           "description": "Gemini provider settings.",
@@ -310,8 +301,7 @@
                               "type": "string"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "host": {
                           "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
@@ -336,8 +326,7 @@
                               "type": "string"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "path": {
                           "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
@@ -363,16 +352,9 @@
                                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                                     "properties": {
                                       "field": {
-                                        "allOf": [
-                                          {
-                                            "minLength": 1
-                                          },
-                                          {
-                                            "minLength": 1
-                                          }
-                                        ],
                                         "description": "Name of the field.",
                                         "maxLength": 256,
+                                        "minLength": 1,
                                         "type": "string"
                                       },
                                       "value": {
@@ -384,8 +366,7 @@
                                       "field",
                                       "value"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -405,16 +386,9 @@
                                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                                     "properties": {
                                       "field": {
-                                        "allOf": [
-                                          {
-                                            "minLength": 1
-                                          },
-                                          {
-                                            "minLength": 1
-                                          }
-                                        ],
                                         "description": "Name of the field.",
                                         "maxLength": 256,
+                                        "minLength": 1,
                                         "type": "string"
                                       },
                                       "value": {
@@ -426,8 +400,7 @@
                                       "field",
                                       "value"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -454,8 +427,7 @@
                                           "content",
                                           "role"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array"
                                     },
@@ -477,14 +449,12 @@
                                           "content",
                                           "role"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "promptCaching": {
                                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -512,13 +482,12 @@
                                     },
                                     "minTokens": {
                                       "default": 1024,
-                                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                                       "minimum": 0,
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "promptGuard": {
                                   "description": "Guardrails for LLM requests and responses.",
@@ -541,10 +510,10 @@
                                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                                 "properties": {
                                                   "auth": {
-                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                                     "properties": {
                                                       "aws": {
-                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                                         "properties": {
                                                           "assumeRole": {
                                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -554,27 +523,90 @@
                                                                 "minLength": 1,
                                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                                 "type": "string"
+                                                              },
+                                                              "sessionName": {
+                                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                                "type": "string"
+                                                              },
+                                                              "sessionNameExpression": {
+                                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              },
+                                                              "tags": {
+                                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                                "items": {
+                                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                                  "properties": {
+                                                                    "expression": {
+                                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                                      "maxLength": 16384,
+                                                                      "minLength": 1,
+                                                                      "type": "string"
+                                                                    },
+                                                                    "key": {
+                                                                      "description": "Key is the tag key.",
+                                                                      "maxLength": 128,
+                                                                      "minLength": 1,
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "description": "Value is a static tag value.",
+                                                                      "maxLength": 256,
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "key"
+                                                                  ],
+                                                                  "type": "object",
+                                                                  "x-kubernetes-validations": [
+                                                                    {
+                                                                      "message": "exactly one of value or expression must be set",
+                                                                      "rule": "has(self.value) != has(self.expression)"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "maxItems": 50,
+                                                                "type": "array",
+                                                                "x-kubernetes-list-map-keys": [
+                                                                  "key"
+                                                                ],
+                                                                "x-kubernetes-list-type": "map"
                                                               }
                                                             },
                                                             "required": [
                                                               "roleArn"
                                                             ],
                                                             "type": "object",
-                                                            "additionalProperties": false
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "region": {
+                                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
                                                           },
                                                           "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                                             "properties": {
                                                               "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                                 "type": "string"
                                                               },
                                                               "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                                 "type": "string"
                                                               },
                                                               "name": {
-                                                                "description": "The name of the referenced credential.",
+                                                                "description": "Name of the referenced credential",
                                                                 "maxLength": 253,
                                                                 "minLength": 1,
                                                                 "type": "string"
@@ -590,8 +622,7 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ],
-                                                            "additionalProperties": false
+                                                            ]
                                                           },
                                                           "serviceName": {
                                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -606,133 +637,15 @@
                                                             "message": "secretRef and assumeRole are mutually exclusive",
                                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "azure": {
-                                                        "description": "Azure authentication method for the backend.",
-                                                        "properties": {
-                                                          "managedIdentity": {
-                                                            "description": "Managed identity authentication settings.",
-                                                            "properties": {
-                                                              "clientId": {
-                                                                "type": "string"
-                                                              },
-                                                              "objectId": {
-                                                                "type": "string"
-                                                              },
-                                                              "resourceId": {
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "clientId",
-                                                              "objectId",
-                                                              "resourceId"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "gcp": {
-                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                                        "properties": {
-                                                          "audience": {
-                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "type": {
-                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                                            "enum": [
-                                                              "AccessToken",
-                                                              "IdToken"
-                                                            ],
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "audience is only valid with IdToken",
-                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       },
                                                       "key": {
-                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                                         "maxLength": 2048,
                                                         "type": "string"
                                                       },
                                                       "location": {
-                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                                         "properties": {
                                                           "cookie": {
                                                             "properties": {
@@ -745,13 +658,12 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "header": {
                                                             "properties": {
                                                               "name": {
-                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                                 "maxLength": 256,
                                                                 "minLength": 1,
                                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -766,8 +678,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -780,8 +691,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           }
                                                         },
                                                         "type": "object",
@@ -790,26 +700,27 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "passthrough": {
-                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                                        "type": "object"
+                                                        ]
                                                       },
                                                       "secretRef": {
-                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                                         "properties": {
                                                           "group": {
-                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                                            "type": "string"
+                                                          },
+                                                          "key": {
+                                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
                                                             "type": "string"
                                                           },
                                                           "kind": {
-                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                             "type": "string"
                                                           },
                                                           "name": {
-                                                            "description": "The name of the referenced credential.",
+                                                            "description": "Name of the referenced credential",
                                                             "maxLength": 253,
                                                             "minLength": 1,
                                                             "type": "string"
@@ -825,28 +736,27 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "type": "object",
                                                     "x-kubernetes-validations": [
                                                       {
-                                                        "message": "location may only be set for key or passthrough auth",
-                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                        "message": "location may only be set for key or secretRef auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                                       },
                                                       {
-                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "http": {
-                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "description": "Settings for managing HTTP requests to the backend",
                                                     "properties": {
                                                       "requestTimeout": {
                                                         "description": "Deadline for receiving a response from the backend.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -860,7 +770,7 @@
                                                         ]
                                                       },
                                                       "version": {
-                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                                         "enum": [
                                                           "HTTP1",
                                                           "HTTP2"
@@ -868,14 +778,14 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tcp": {
-                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "description": "Settings for managing TCP connections to the backend",
                                                     "properties": {
                                                       "connectTimeout": {
                                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -893,6 +803,7 @@
                                                         "properties": {
                                                           "interval": {
                                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -914,6 +825,7 @@
                                                           },
                                                           "time": {
                                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -927,15 +839,13 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tls": {
-                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                                     "properties": {
                                                       "alpnProtocols": {
                                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -955,20 +865,19 @@
                                                           "properties": {
                                                             "name": {
                                                               "default": "",
-                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "description": "Name of the referent",
                                                               "type": "string"
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic",
-                                                          "additionalProperties": false
+                                                          "x-kubernetes-map-type": "atomic"
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
                                                         "x-kubernetes-list-type": "atomic"
                                                       },
                                                       "insecureSkipVerify": {
-                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                                         "enum": [
                                                           "All",
                                                           "Hostname"
@@ -989,20 +898,20 @@
                                                         "type": "array"
                                                       },
                                                       "mtlsCertificateRef": {
-                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                                         "items": {
-                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                                           "properties": {
                                                             "group": {
-                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "description": "API group of the referenced credential; empty selects the core API group",
                                                               "type": "string"
                                                             },
                                                             "kind": {
-                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                               "type": "string"
                                                             },
                                                             "name": {
-                                                              "description": "The name of the referenced credential.",
+                                                              "description": "Name of the referenced credential",
                                                               "maxLength": 253,
                                                               "minLength": 1,
                                                               "type": "string"
@@ -1018,8 +927,7 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ],
-                                                          "additionalProperties": false
+                                                          ]
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1058,25 +966,24 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "tunnel": {
-                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                                     "properties": {
                                                       "backendRef": {
                                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                                         "properties": {
                                                           "group": {
                                                             "default": "",
-                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                             "maxLength": 253,
                                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                             "type": "string"
                                                           },
                                                           "kind": {
                                                             "default": "Service",
-                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -1089,14 +996,14 @@
                                                             "type": "string"
                                                           },
                                                           "namespace": {
-                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                             "type": "string"
                                                           },
                                                           "port": {
-                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                             "format": "int32",
                                                             "maximum": 65535,
                                                             "minimum": 1,
@@ -1112,19 +1019,22 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   }
                                                 },
                                                 "type": "object",
-                                                "additionalProperties": false
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                                  }
+                                                ]
                                               },
                                               "region": {
                                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -1144,8 +1054,7 @@
                                               "region",
                                               "version"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "googleModelArmor": {
                                             "description": "Google Model Armor settings for prompt guarding.",
@@ -1161,135 +1070,10 @@
                                                 "description": "Policies for communicating with Google Model Armor.",
                                                 "properties": {
                                                   "auth": {
-                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "description": "Settings for authenticating to Google Model Armor.",
                                                     "properties": {
-                                                      "aws": {
-                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                                        "properties": {
-                                                          "assumeRole": {
-                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                                            "properties": {
-                                                              "roleArn": {
-                                                                "description": "AWS IAM role ARN to assume.",
-                                                                "minLength": 1,
-                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "roleArn"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "serviceName": {
-                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "azure": {
-                                                        "description": "Azure authentication method for the backend.",
-                                                        "properties": {
-                                                          "managedIdentity": {
-                                                            "description": "Managed identity authentication settings.",
-                                                            "properties": {
-                                                              "clientId": {
-                                                                "type": "string"
-                                                              },
-                                                              "objectId": {
-                                                                "type": "string"
-                                                              },
-                                                              "resourceId": {
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "clientId",
-                                                              "objectId",
-                                                              "resourceId"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
                                                       "gcp": {
-                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                                         "properties": {
                                                           "audience": {
                                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -1298,18 +1082,24 @@
                                                             "type": "string"
                                                           },
                                                           "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                                             "properties": {
                                                               "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                                "type": "string"
+                                                              },
+                                                              "key": {
+                                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
                                                                 "type": "string"
                                                               },
                                                               "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                                 "type": "string"
                                                               },
                                                               "name": {
-                                                                "description": "The name of the referenced credential.",
+                                                                "description": "Name of the referenced credential",
                                                                 "maxLength": 253,
                                                                 "minLength": 1,
                                                                 "type": "string"
@@ -1325,8 +1115,7 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ],
-                                                            "additionalProperties": false
+                                                            ]
                                                           },
                                                           "type": {
                                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -1343,130 +1132,23 @@
                                                             "message": "audience is only valid with IdToken",
                                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "key": {
-                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                                        "maxLength": 2048,
-                                                        "type": "string"
-                                                      },
-                                                      "location": {
-                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                                        "properties": {
-                                                          "cookie": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "header": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                                "type": "string"
-                                                              },
-                                                              "prefix": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "queryParameter": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "passthrough": {
-                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                                        "type": "object"
-                                                      },
-                                                      "secretRef": {
-                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                                        "properties": {
-                                                          "group": {
-                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                            "type": "string"
-                                                          },
-                                                          "kind": {
-                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                            "type": "string"
-                                                          },
-                                                          "name": {
-                                                            "description": "The name of the referenced credential.",
-                                                            "maxLength": 253,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "name"
-                                                        ],
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "custom credential refs must set both group and kind",
-                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "type": "object",
                                                     "x-kubernetes-validations": [
                                                       {
-                                                        "message": "location may only be set for key or passthrough auth",
-                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                                      },
-                                                      {
-                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                        "message": "exactly one of the fields in [gcp] must be set",
+                                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "http": {
-                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "description": "Settings for managing HTTP requests to the backend",
                                                     "properties": {
                                                       "requestTimeout": {
                                                         "description": "Deadline for receiving a response from the backend.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -1480,7 +1162,7 @@
                                                         ]
                                                       },
                                                       "version": {
-                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                                         "enum": [
                                                           "HTTP1",
                                                           "HTTP2"
@@ -1488,14 +1170,14 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tcp": {
-                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "description": "Settings for managing TCP connections to the backend",
                                                     "properties": {
                                                       "connectTimeout": {
                                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -1513,6 +1195,7 @@
                                                         "properties": {
                                                           "interval": {
                                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -1534,6 +1217,7 @@
                                                           },
                                                           "time": {
                                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -1547,15 +1231,13 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tls": {
-                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                                     "properties": {
                                                       "alpnProtocols": {
                                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -1575,20 +1257,19 @@
                                                           "properties": {
                                                             "name": {
                                                               "default": "",
-                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "description": "Name of the referent",
                                                               "type": "string"
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic",
-                                                          "additionalProperties": false
+                                                          "x-kubernetes-map-type": "atomic"
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
                                                         "x-kubernetes-list-type": "atomic"
                                                       },
                                                       "insecureSkipVerify": {
-                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                                         "enum": [
                                                           "All",
                                                           "Hostname"
@@ -1609,20 +1290,20 @@
                                                         "type": "array"
                                                       },
                                                       "mtlsCertificateRef": {
-                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                                         "items": {
-                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                                           "properties": {
                                                             "group": {
-                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "description": "API group of the referenced credential; empty selects the core API group",
                                                               "type": "string"
                                                             },
                                                             "kind": {
-                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                               "type": "string"
                                                             },
                                                             "name": {
-                                                              "description": "The name of the referenced credential.",
+                                                              "description": "Name of the referenced credential",
                                                               "maxLength": 253,
                                                               "minLength": 1,
                                                               "type": "string"
@@ -1638,8 +1319,7 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ],
-                                                          "additionalProperties": false
+                                                          ]
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1678,25 +1358,24 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "tunnel": {
-                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                                     "properties": {
                                                       "backendRef": {
                                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                                         "properties": {
                                                           "group": {
                                                             "default": "",
-                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                             "maxLength": 253,
                                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                             "type": "string"
                                                           },
                                                           "kind": {
                                                             "default": "Service",
-                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -1709,14 +1388,14 @@
                                                             "type": "string"
                                                           },
                                                           "namespace": {
-                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                             "type": "string"
                                                           },
                                                           "port": {
-                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                             "format": "int32",
                                                             "maximum": 65535,
                                                             "minimum": 1,
@@ -1732,19 +1411,22 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   }
                                                 },
                                                 "type": "object",
-                                                "additionalProperties": false
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                                  }
+                                                ]
                                               },
                                               "projectId": {
                                                 "description": "Google Cloud project ID.",
@@ -1763,8 +1445,7 @@
                                               "projectId",
                                               "templateId"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "openAIModeration": {
                                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -1777,198 +1458,15 @@
                                                 "description": "Policies for communicating with OpenAI.",
                                                 "properties": {
                                                   "auth": {
-                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "description": "Settings for authenticating to OpenAI.",
                                                     "properties": {
-                                                      "aws": {
-                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                                        "properties": {
-                                                          "assumeRole": {
-                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                                            "properties": {
-                                                              "roleArn": {
-                                                                "description": "AWS IAM role ARN to assume.",
-                                                                "minLength": 1,
-                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "roleArn"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "serviceName": {
-                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "azure": {
-                                                        "description": "Azure authentication method for the backend.",
-                                                        "properties": {
-                                                          "managedIdentity": {
-                                                            "description": "Managed identity authentication settings.",
-                                                            "properties": {
-                                                              "clientId": {
-                                                                "type": "string"
-                                                              },
-                                                              "objectId": {
-                                                                "type": "string"
-                                                              },
-                                                              "resourceId": {
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "clientId",
-                                                              "objectId",
-                                                              "resourceId"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "gcp": {
-                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                                        "properties": {
-                                                          "audience": {
-                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "type": {
-                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                                            "enum": [
-                                                              "AccessToken",
-                                                              "IdToken"
-                                                            ],
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "audience is only valid with IdToken",
-                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
                                                       "key": {
                                                         "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
                                                         "maxLength": 2048,
                                                         "type": "string"
                                                       },
                                                       "location": {
-                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "description": "Where backend credentials are inserted. Defaults to the `Authorization`\nheader with the `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                                         "properties": {
                                                           "cookie": {
                                                             "properties": {
@@ -1981,13 +1479,12 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "header": {
                                                             "properties": {
                                                               "name": {
-                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                                 "maxLength": 256,
                                                                 "minLength": 1,
                                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -2002,8 +1499,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -2016,8 +1512,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           }
                                                         },
                                                         "type": "object",
@@ -2026,26 +1521,27 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "passthrough": {
-                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                                        "type": "object"
+                                                        ]
                                                       },
                                                       "secretRef": {
-                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                                         "properties": {
                                                           "group": {
-                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                                            "type": "string"
+                                                          },
+                                                          "key": {
+                                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
                                                             "type": "string"
                                                           },
                                                           "kind": {
-                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                             "type": "string"
                                                           },
                                                           "name": {
-                                                            "description": "The name of the referenced credential.",
+                                                            "description": "Name of the referenced credential",
                                                             "maxLength": 253,
                                                             "minLength": 1,
                                                             "type": "string"
@@ -2061,28 +1557,23 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "type": "object",
                                                     "x-kubernetes-validations": [
                                                       {
-                                                        "message": "location may only be set for key or passthrough auth",
-                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                                      },
-                                                      {
-                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                        "message": "exactly one of the fields in [key secretRef] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "http": {
-                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "description": "Settings for managing HTTP requests to the backend",
                                                     "properties": {
                                                       "requestTimeout": {
                                                         "description": "Deadline for receiving a response from the backend.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -2096,7 +1587,7 @@
                                                         ]
                                                       },
                                                       "version": {
-                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                                         "enum": [
                                                           "HTTP1",
                                                           "HTTP2"
@@ -2104,14 +1595,14 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tcp": {
-                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "description": "Settings for managing TCP connections to the backend",
                                                     "properties": {
                                                       "connectTimeout": {
                                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -2129,6 +1620,7 @@
                                                         "properties": {
                                                           "interval": {
                                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -2150,6 +1642,7 @@
                                                           },
                                                           "time": {
                                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -2163,15 +1656,13 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tls": {
-                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                                     "properties": {
                                                       "alpnProtocols": {
                                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -2191,20 +1682,19 @@
                                                           "properties": {
                                                             "name": {
                                                               "default": "",
-                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "description": "Name of the referent",
                                                               "type": "string"
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic",
-                                                          "additionalProperties": false
+                                                          "x-kubernetes-map-type": "atomic"
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
                                                         "x-kubernetes-list-type": "atomic"
                                                       },
                                                       "insecureSkipVerify": {
-                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                                         "enum": [
                                                           "All",
                                                           "Hostname"
@@ -2225,20 +1715,20 @@
                                                         "type": "array"
                                                       },
                                                       "mtlsCertificateRef": {
-                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                                         "items": {
-                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                                           "properties": {
                                                             "group": {
-                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "description": "API group of the referenced credential; empty selects the core API group",
                                                               "type": "string"
                                                             },
                                                             "kind": {
-                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                               "type": "string"
                                                             },
                                                             "name": {
-                                                              "description": "The name of the referenced credential.",
+                                                              "description": "Name of the referenced credential",
                                                               "maxLength": 253,
                                                               "minLength": 1,
                                                               "type": "string"
@@ -2254,8 +1744,7 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ],
-                                                          "additionalProperties": false
+                                                          ]
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -2294,25 +1783,24 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "tunnel": {
-                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                                     "properties": {
                                                       "backendRef": {
                                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                                         "properties": {
                                                           "group": {
                                                             "default": "",
-                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                             "maxLength": 253,
                                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                             "type": "string"
                                                           },
                                                           "kind": {
                                                             "default": "Service",
-                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -2325,14 +1813,14 @@
                                                             "type": "string"
                                                           },
                                                           "namespace": {
-                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                             "type": "string"
                                                           },
                                                           "port": {
-                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                             "format": "int32",
                                                             "maximum": 65535,
                                                             "minimum": 1,
@@ -2348,23 +1836,25 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   }
                                                 },
                                                 "type": "object",
-                                                "additionalProperties": false
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                                  }
+                                                ]
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "regex": {
                                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -2403,8 +1893,7 @@
                                                 "type": "array"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "response": {
                                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -2429,8 +1918,7 @@
                                                 "message": "at least one of the fields in [message statusCode] must be set",
                                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "webhook": {
                                             "description": "Webhook that receives requests for prompt guarding.",
@@ -2440,14 +1928,14 @@
                                                 "properties": {
                                                   "group": {
                                                     "default": "",
-                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                     "maxLength": 253,
                                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                     "type": "string"
                                                   },
                                                   "kind": {
                                                     "default": "Service",
-                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                     "maxLength": 63,
                                                     "minLength": 1,
                                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -2460,14 +1948,14 @@
                                                     "type": "string"
                                                   },
                                                   "namespace": {
-                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                     "maxLength": 63,
                                                     "minLength": 1,
                                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                     "type": "string"
                                                   },
                                                   "port": {
-                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                     "format": "int32",
                                                     "maximum": 65535,
                                                     "minimum": 1,
@@ -2483,8 +1971,7 @@
                                                     "message": "Must have port for Service reference",
                                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                   }
-                                                ],
-                                                "additionalProperties": false
+                                                ]
                                               },
                                               "failureMode": {
                                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -2500,7 +1987,7 @@
                                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                                   "properties": {
                                                     "name": {
-                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                                       "maxLength": 256,
                                                       "minLength": 1,
                                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -2508,7 +1995,7 @@
                                                     },
                                                     "type": {
                                                       "default": "Exact",
-                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                                       "enum": [
                                                         "Exact",
                                                         "RegularExpression"
@@ -2516,7 +2003,7 @@
                                                       "type": "string"
                                                     },
                                                     "value": {
-                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "description": "Value of the HTTP header to match",
                                                       "maxLength": 4096,
                                                       "minLength": 1,
                                                       "type": "string"
@@ -2526,17 +2013,26 @@
                                                     "name",
                                                     "value"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "type": "array"
+                                              },
+                                              "headers": {
+                                                "additionalProperties": {
+                                                  "description": "A Common Expression Language (CEL) expression.",
+                                                  "maxLength": 16384,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "description": "CEL-computed headers to include in webhook requests.",
+                                                "maxProperties": 64,
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "backendRef"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -2545,8 +2041,7 @@
                                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "maxItems": 8,
                                       "minItems": 1,
@@ -2570,10 +2065,10 @@
                                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                                 "properties": {
                                                   "auth": {
-                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                                     "properties": {
                                                       "aws": {
-                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                                         "properties": {
                                                           "assumeRole": {
                                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -2583,27 +2078,90 @@
                                                                 "minLength": 1,
                                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                                 "type": "string"
+                                                              },
+                                                              "sessionName": {
+                                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                                "type": "string"
+                                                              },
+                                                              "sessionNameExpression": {
+                                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              },
+                                                              "tags": {
+                                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                                "items": {
+                                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                                  "properties": {
+                                                                    "expression": {
+                                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                                      "maxLength": 16384,
+                                                                      "minLength": 1,
+                                                                      "type": "string"
+                                                                    },
+                                                                    "key": {
+                                                                      "description": "Key is the tag key.",
+                                                                      "maxLength": 128,
+                                                                      "minLength": 1,
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "description": "Value is a static tag value.",
+                                                                      "maxLength": 256,
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "key"
+                                                                  ],
+                                                                  "type": "object",
+                                                                  "x-kubernetes-validations": [
+                                                                    {
+                                                                      "message": "exactly one of value or expression must be set",
+                                                                      "rule": "has(self.value) != has(self.expression)"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "maxItems": 50,
+                                                                "type": "array",
+                                                                "x-kubernetes-list-map-keys": [
+                                                                  "key"
+                                                                ],
+                                                                "x-kubernetes-list-type": "map"
                                                               }
                                                             },
                                                             "required": [
                                                               "roleArn"
                                                             ],
                                                             "type": "object",
-                                                            "additionalProperties": false
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "region": {
+                                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
                                                           },
                                                           "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                                             "properties": {
                                                               "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                                 "type": "string"
                                                               },
                                                               "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                                 "type": "string"
                                                               },
                                                               "name": {
-                                                                "description": "The name of the referenced credential.",
+                                                                "description": "Name of the referenced credential",
                                                                 "maxLength": 253,
                                                                 "minLength": 1,
                                                                 "type": "string"
@@ -2619,8 +2177,7 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ],
-                                                            "additionalProperties": false
+                                                            ]
                                                           },
                                                           "serviceName": {
                                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -2635,133 +2192,15 @@
                                                             "message": "secretRef and assumeRole are mutually exclusive",
                                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "azure": {
-                                                        "description": "Azure authentication method for the backend.",
-                                                        "properties": {
-                                                          "managedIdentity": {
-                                                            "description": "Managed identity authentication settings.",
-                                                            "properties": {
-                                                              "clientId": {
-                                                                "type": "string"
-                                                              },
-                                                              "objectId": {
-                                                                "type": "string"
-                                                              },
-                                                              "resourceId": {
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "clientId",
-                                                              "objectId",
-                                                              "resourceId"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "gcp": {
-                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                                        "properties": {
-                                                          "audience": {
-                                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "type": {
-                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                                            "enum": [
-                                                              "AccessToken",
-                                                              "IdToken"
-                                                            ],
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "audience is only valid with IdToken",
-                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       },
                                                       "key": {
-                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                                         "maxLength": 2048,
                                                         "type": "string"
                                                       },
                                                       "location": {
-                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                                         "properties": {
                                                           "cookie": {
                                                             "properties": {
@@ -2774,13 +2213,12 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "header": {
                                                             "properties": {
                                                               "name": {
-                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                                 "maxLength": 256,
                                                                 "minLength": 1,
                                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -2795,8 +2233,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -2809,8 +2246,7 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           }
                                                         },
                                                         "type": "object",
@@ -2819,26 +2255,27 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "passthrough": {
-                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                                        "type": "object"
+                                                        ]
                                                       },
                                                       "secretRef": {
-                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                                         "properties": {
                                                           "group": {
-                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                                            "type": "string"
+                                                          },
+                                                          "key": {
+                                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
                                                             "type": "string"
                                                           },
                                                           "kind": {
-                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                             "type": "string"
                                                           },
                                                           "name": {
-                                                            "description": "The name of the referenced credential.",
+                                                            "description": "Name of the referenced credential",
                                                             "maxLength": 253,
                                                             "minLength": 1,
                                                             "type": "string"
@@ -2854,28 +2291,27 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "type": "object",
                                                     "x-kubernetes-validations": [
                                                       {
-                                                        "message": "location may only be set for key or passthrough auth",
-                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                        "message": "location may only be set for key or secretRef auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                                       },
                                                       {
-                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "http": {
-                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "description": "Settings for managing HTTP requests to the backend",
                                                     "properties": {
                                                       "requestTimeout": {
                                                         "description": "Deadline for receiving a response from the backend.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -2889,7 +2325,7 @@
                                                         ]
                                                       },
                                                       "version": {
-                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                                         "enum": [
                                                           "HTTP1",
                                                           "HTTP2"
@@ -2897,14 +2333,14 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tcp": {
-                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "description": "Settings for managing TCP connections to the backend",
                                                     "properties": {
                                                       "connectTimeout": {
                                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -2922,6 +2358,7 @@
                                                         "properties": {
                                                           "interval": {
                                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -2943,6 +2380,7 @@
                                                           },
                                                           "time": {
                                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -2956,15 +2394,13 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tls": {
-                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                                     "properties": {
                                                       "alpnProtocols": {
                                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -2984,20 +2420,19 @@
                                                           "properties": {
                                                             "name": {
                                                               "default": "",
-                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "description": "Name of the referent",
                                                               "type": "string"
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic",
-                                                          "additionalProperties": false
+                                                          "x-kubernetes-map-type": "atomic"
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
                                                         "x-kubernetes-list-type": "atomic"
                                                       },
                                                       "insecureSkipVerify": {
-                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                                         "enum": [
                                                           "All",
                                                           "Hostname"
@@ -3018,20 +2453,20 @@
                                                         "type": "array"
                                                       },
                                                       "mtlsCertificateRef": {
-                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                                         "items": {
-                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                                           "properties": {
                                                             "group": {
-                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "description": "API group of the referenced credential; empty selects the core API group",
                                                               "type": "string"
                                                             },
                                                             "kind": {
-                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                               "type": "string"
                                                             },
                                                             "name": {
-                                                              "description": "The name of the referenced credential.",
+                                                              "description": "Name of the referenced credential",
                                                               "maxLength": 253,
                                                               "minLength": 1,
                                                               "type": "string"
@@ -3047,8 +2482,7 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ],
-                                                          "additionalProperties": false
+                                                          ]
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -3087,25 +2521,24 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "tunnel": {
-                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                                     "properties": {
                                                       "backendRef": {
                                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                                         "properties": {
                                                           "group": {
                                                             "default": "",
-                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                             "maxLength": 253,
                                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                             "type": "string"
                                                           },
                                                           "kind": {
                                                             "default": "Service",
-                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -3118,14 +2551,14 @@
                                                             "type": "string"
                                                           },
                                                           "namespace": {
-                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                             "type": "string"
                                                           },
                                                           "port": {
-                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                             "format": "int32",
                                                             "maximum": 65535,
                                                             "minimum": 1,
@@ -3141,19 +2574,22 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   }
                                                 },
                                                 "type": "object",
-                                                "additionalProperties": false
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                                  }
+                                                ]
                                               },
                                               "region": {
                                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -3173,8 +2609,7 @@
                                               "region",
                                               "version"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "googleModelArmor": {
                                             "description": "Google Model Armor settings for prompt guarding.",
@@ -3190,135 +2625,10 @@
                                                 "description": "Policies for communicating with Google Model Armor.",
                                                 "properties": {
                                                   "auth": {
-                                                    "description": "Settings for managing authentication to the backend.",
+                                                    "description": "Settings for authenticating to Google Model Armor.",
                                                     "properties": {
-                                                      "aws": {
-                                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                                        "properties": {
-                                                          "assumeRole": {
-                                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                                            "properties": {
-                                                              "roleArn": {
-                                                                "description": "AWS IAM role ARN to assume.",
-                                                                "minLength": 1,
-                                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "roleArn"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          },
-                                                          "serviceName": {
-                                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                                            "maxLength": 256,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "azure": {
-                                                        "description": "Azure authentication method for the backend.",
-                                                        "properties": {
-                                                          "managedIdentity": {
-                                                            "description": "Managed identity authentication settings.",
-                                                            "properties": {
-                                                              "clientId": {
-                                                                "type": "string"
-                                                              },
-                                                              "objectId": {
-                                                                "type": "string"
-                                                              },
-                                                              "resourceId": {
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "clientId",
-                                                              "objectId",
-                                                              "resourceId"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                                            "properties": {
-                                                              "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                                "type": "string"
-                                                              },
-                                                              "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                                "type": "string"
-                                                              },
-                                                              "name": {
-                                                                "description": "The name of the referenced credential.",
-                                                                "maxLength": 253,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "x-kubernetes-validations": [
-                                                              {
-                                                                "message": "custom credential refs must set both group and kind",
-                                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                              }
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
                                                       "gcp": {
-                                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                                         "properties": {
                                                           "audience": {
                                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -3327,18 +2637,24 @@
                                                             "type": "string"
                                                           },
                                                           "secretRef": {
-                                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                                             "properties": {
                                                               "group": {
-                                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                                "type": "string"
+                                                              },
+                                                              "key": {
+                                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                                "maxLength": 253,
+                                                                "minLength": 1,
                                                                 "type": "string"
                                                               },
                                                               "kind": {
-                                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                                 "type": "string"
                                                               },
                                                               "name": {
-                                                                "description": "The name of the referenced credential.",
+                                                                "description": "Name of the referenced credential",
                                                                 "maxLength": 253,
                                                                 "minLength": 1,
                                                                 "type": "string"
@@ -3354,8 +2670,7 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ],
-                                                            "additionalProperties": false
+                                                            ]
                                                           },
                                                           "type": {
                                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -3372,130 +2687,23 @@
                                                             "message": "audience is only valid with IdToken",
                                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "key": {
-                                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                                        "maxLength": 2048,
-                                                        "type": "string"
-                                                      },
-                                                      "location": {
-                                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                                        "properties": {
-                                                          "cookie": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "header": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                                "type": "string"
-                                                              },
-                                                              "prefix": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          },
-                                                          "queryParameter": {
-                                                            "properties": {
-                                                              "name": {
-                                                                "maxLength": 256,
-                                                                "minLength": 1,
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "name"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
-                                                      },
-                                                      "passthrough": {
-                                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                                        "type": "object"
-                                                      },
-                                                      "secretRef": {
-                                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                                        "properties": {
-                                                          "group": {
-                                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                            "type": "string"
-                                                          },
-                                                          "kind": {
-                                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                            "type": "string"
-                                                          },
-                                                          "name": {
-                                                            "description": "The name of the referenced credential.",
-                                                            "maxLength": 253,
-                                                            "minLength": 1,
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "name"
-                                                        ],
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "x-kubernetes-validations": [
-                                                          {
-                                                            "message": "custom credential refs must set both group and kind",
-                                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                                          }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "type": "object",
                                                     "x-kubernetes-validations": [
                                                       {
-                                                        "message": "location may only be set for key or passthrough auth",
-                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                                      },
-                                                      {
-                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                        "message": "exactly one of the fields in [gcp] must be set",
+                                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "http": {
-                                                    "description": "Settings for managing HTTP requests to the backend.",
+                                                    "description": "Settings for managing HTTP requests to the backend",
                                                     "properties": {
                                                       "requestTimeout": {
                                                         "description": "Deadline for receiving a response from the backend.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -3509,7 +2717,7 @@
                                                         ]
                                                       },
                                                       "version": {
-                                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                                         "enum": [
                                                           "HTTP1",
                                                           "HTTP2"
@@ -3517,14 +2725,14 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tcp": {
-                                                    "description": "Settings for managing TCP connections to the backend.",
+                                                    "description": "Settings for managing TCP connections to the backend",
                                                     "properties": {
                                                       "connectTimeout": {
                                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                                        "maxLength": 32,
                                                         "type": "string",
                                                         "x-kubernetes-validations": [
                                                           {
@@ -3542,6 +2750,7 @@
                                                         "properties": {
                                                           "interval": {
                                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -3563,6 +2772,7 @@
                                                           },
                                                           "time": {
                                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "maxLength": 32,
                                                             "type": "string",
                                                             "x-kubernetes-validations": [
                                                               {
@@ -3576,15 +2786,13 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       }
                                                     },
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
                                                   "tls": {
-                                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                                     "properties": {
                                                       "alpnProtocols": {
                                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -3604,20 +2812,19 @@
                                                           "properties": {
                                                             "name": {
                                                               "default": "",
-                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "description": "Name of the referent",
                                                               "type": "string"
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic",
-                                                          "additionalProperties": false
+                                                          "x-kubernetes-map-type": "atomic"
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
                                                         "x-kubernetes-list-type": "atomic"
                                                       },
                                                       "insecureSkipVerify": {
-                                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                                         "enum": [
                                                           "All",
                                                           "Hostname"
@@ -3638,20 +2845,20 @@
                                                         "type": "array"
                                                       },
                                                       "mtlsCertificateRef": {
-                                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                                         "items": {
-                                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                                           "properties": {
                                                             "group": {
-                                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                              "description": "API group of the referenced credential; empty selects the core API group",
                                                               "type": "string"
                                                             },
                                                             "kind": {
-                                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                               "type": "string"
                                                             },
                                                             "name": {
-                                                              "description": "The name of the referenced credential.",
+                                                              "description": "Name of the referenced credential",
                                                               "maxLength": 253,
                                                               "minLength": 1,
                                                               "type": "string"
@@ -3667,8 +2874,7 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ],
-                                                          "additionalProperties": false
+                                                          ]
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -3707,25 +2913,24 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ],
-                                                    "additionalProperties": false
+                                                    ]
                                                   },
                                                   "tunnel": {
-                                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                                     "properties": {
                                                       "backendRef": {
                                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                                         "properties": {
                                                           "group": {
                                                             "default": "",
-                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                             "maxLength": 253,
                                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                             "type": "string"
                                                           },
                                                           "kind": {
                                                             "default": "Service",
-                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -3738,14 +2943,14 @@
                                                             "type": "string"
                                                           },
                                                           "namespace": {
-                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                             "maxLength": 63,
                                                             "minLength": 1,
                                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                             "type": "string"
                                                           },
                                                           "port": {
-                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                             "format": "int32",
                                                             "maximum": 65535,
                                                             "minimum": 1,
@@ -3761,19 +2966,22 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ],
-                                                        "additionalProperties": false
+                                                        ]
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   }
                                                 },
                                                 "type": "object",
-                                                "additionalProperties": false
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                                  }
+                                                ]
                                               },
                                               "projectId": {
                                                 "description": "Google Cloud project ID.",
@@ -3792,8 +3000,7 @@
                                               "projectId",
                                               "templateId"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "regex": {
                                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -3832,8 +3039,7 @@
                                                 "type": "array"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "response": {
                                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -3858,8 +3064,7 @@
                                                 "message": "at least one of the fields in [message statusCode] must be set",
                                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "webhook": {
                                             "description": "Webhook that receives responses for prompt guarding.",
@@ -3869,14 +3074,14 @@
                                                 "properties": {
                                                   "group": {
                                                     "default": "",
-                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                                     "maxLength": 253,
                                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                                     "type": "string"
                                                   },
                                                   "kind": {
                                                     "default": "Service",
-                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                                     "maxLength": 63,
                                                     "minLength": 1,
                                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -3889,14 +3094,14 @@
                                                     "type": "string"
                                                   },
                                                   "namespace": {
-                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                                     "maxLength": 63,
                                                     "minLength": 1,
                                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                                     "type": "string"
                                                   },
                                                   "port": {
-                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                                     "format": "int32",
                                                     "maximum": 65535,
                                                     "minimum": 1,
@@ -3912,8 +3117,7 @@
                                                     "message": "Must have port for Service reference",
                                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                   }
-                                                ],
-                                                "additionalProperties": false
+                                                ]
                                               },
                                               "failureMode": {
                                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -3929,7 +3133,7 @@
                                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                                   "properties": {
                                                     "name": {
-                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                                       "maxLength": 256,
                                                       "minLength": 1,
                                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -3937,7 +3141,7 @@
                                                     },
                                                     "type": {
                                                       "default": "Exact",
-                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                                       "enum": [
                                                         "Exact",
                                                         "RegularExpression"
@@ -3945,7 +3149,7 @@
                                                       "type": "string"
                                                     },
                                                     "value": {
-                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "description": "Value of the HTTP header to match",
                                                       "maxLength": 4096,
                                                       "minLength": 1,
                                                       "type": "string"
@@ -3955,17 +3159,26 @@
                                                     "name",
                                                     "value"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "type": "array"
+                                              },
+                                              "headers": {
+                                                "additionalProperties": {
+                                                  "description": "A Common Expression Language (CEL) expression.",
+                                                  "maxLength": 16384,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "description": "CEL-computed headers to include in webhook requests.",
+                                                "maxProperties": 64,
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "backendRef"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -3974,8 +3187,7 @@
                                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "maxItems": 8,
                                       "minItems": 1,
@@ -3995,8 +3207,7 @@
                                       "message": "at least one of the fields in [request response] must be set",
                                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 },
                                 "routes": {
                                   "additionalProperties": {
@@ -4030,16 +3241,9 @@
                                         "type": "string"
                                       },
                                       "field": {
-                                        "allOf": [
-                                          {
-                                            "minLength": 1
-                                          },
-                                          {
-                                            "minLength": 1
-                                          }
-                                        ],
                                         "description": "Name of the field to set.",
                                         "maxLength": 256,
+                                        "minLength": 1,
                                         "type": "string"
                                       }
                                     },
@@ -4047,8 +3251,7 @@
                                       "expression",
                                       "field"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -4061,11 +3264,10 @@
                                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "auth": {
-                              "description": "Settings for managing authentication to the backend.",
+                              "description": "Settings for managing authentication to the backend",
                               "properties": {
                                 "aws": {
                                   "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
@@ -4078,27 +3280,90 @@
                                           "minLength": 1,
                                           "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                           "type": "string"
+                                        },
+                                        "sessionName": {
+                                          "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                          "pattern": "^[\\w+=,.@-]{2,64}$",
+                                          "type": "string"
+                                        },
+                                        "sessionNameExpression": {
+                                          "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                          "maxLength": 16384,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "tags": {
+                                          "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                          "items": {
+                                            "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                            "properties": {
+                                              "expression": {
+                                                "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                "maxLength": 16384,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key is the tag key.",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "Value is a static tag value.",
+                                                "maxLength": 256,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "exactly one of value or expression must be set",
+                                                "rule": "has(self.value) != has(self.expression)"
+                                              }
+                                            ]
+                                          },
+                                          "maxItems": 50,
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "key"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         }
                                       },
                                       "required": [
                                         "roleArn"
                                       ],
                                       "type": "object",
-                                      "additionalProperties": false
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                          "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                        }
+                                      ]
+                                    },
+                                    "region": {
+                                      "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
                                     },
                                     "secretRef": {
-                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                      "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                       "properties": {
                                         "group": {
-                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "description": "API group of the referenced credential; empty selects the core API group",
                                           "type": "string"
                                         },
                                         "kind": {
-                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                           "type": "string"
                                         },
                                         "name": {
-                                          "description": "The name of the referenced credential.",
+                                          "description": "Name of the referenced credential",
                                           "maxLength": 253,
                                           "minLength": 1,
                                           "type": "string"
@@ -4114,8 +3379,7 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ],
-                                      "additionalProperties": false
+                                      ]
                                     },
                                     "serviceName": {
                                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -4130,8 +3394,7 @@
                                       "message": "secretRef and assumeRole are mutually exclusive",
                                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 },
                                 "azure": {
                                   "description": "Azure authentication method for the backend.",
@@ -4154,22 +3417,21 @@
                                         "objectId",
                                         "resourceId"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "secretRef": {
-                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                      "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
                                       "properties": {
                                         "group": {
-                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "description": "API group of the referenced credential; empty selects the core API group",
                                           "type": "string"
                                         },
                                         "kind": {
-                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                           "type": "string"
                                         },
                                         "name": {
-                                          "description": "The name of the referenced credential.",
+                                          "description": "Name of the referenced credential",
                                           "maxLength": 253,
                                           "minLength": 1,
                                           "type": "string"
@@ -4185,12 +3447,766 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ],
-                                      "additionalProperties": false
+                                      ]
+                                    },
+                                    "workloadIdentity": {
+                                      "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
+                                      "type": "object"
                                     }
                                   },
                                   "type": "object",
-                                  "additionalProperties": false
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
+                                      "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
+                                    }
+                                  ]
+                                },
+                                "credentials": {
+                                  "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
+                                  "items": {
+                                    "description": "BackendAuthCredential specifies one additional credential to inject on the\nbackend request.",
+                                    "properties": {
+                                      "location": {
+                                        "description": "Where the credential is inserted on the backend request.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "secretRef": {
+                                        "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "location",
+                                      "secretRef"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 8,
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "crossAppAccess": {
+                                  "description": "Cross App Access (Identity Assertion / ID-JAG) authentication.",
+                                  "properties": {
+                                    "audience": {
+                                      "description": "Identifier of the resource authorization server. The issued ID-JAG is bound to this audience.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "cache": {
+                                      "description": "Response cache configuration.",
+                                      "properties": {
+                                        "inMemory": {
+                                          "properties": {
+                                            "defaultTtl": {
+                                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                                              "type": "string"
+                                            },
+                                            "maxEntries": {
+                                              "description": "Default 8192; 0 disables the cache.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "identityProvider": {
+                                      "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
+                                      "properties": {
+                                        "backendRef": {
+                                          "description": "Token endpoint backend.",
+                                          "properties": {
+                                            "group": {
+                                              "default": "",
+                                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                              "maxLength": 253,
+                                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "default": "Service",
+                                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                              "maxLength": 63,
+                                              "minLength": 1,
+                                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of the referent.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                              "maxLength": 63,
+                                              "minLength": 1,
+                                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                              "format": "int32",
+                                              "maximum": 65535,
+                                              "minimum": 1,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "Must have port for Service reference",
+                                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                            }
+                                          ]
+                                        },
+                                        "clientAuth": {
+                                          "description": "Client authentication for the token endpoint.",
+                                          "properties": {
+                                            "clientId": {
+                                              "description": "Client ID sent to the token endpoint.",
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "method": {
+                                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                              "enum": [
+                                                "ClientSecretBasic",
+                                                "ClientSecretPost",
+                                                "PrivateKeyJwt"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "privateKeyJwt": {
+                                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                              "properties": {
+                                                "alg": {
+                                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                                  "enum": [
+                                                    "ES256",
+                                                    "ES384",
+                                                    "PS256",
+                                                    "RS256",
+                                                    "RS384",
+                                                    "RS512"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "assertionAudience": {
+                                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "certificateHeader": {
+                                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                                  "enum": [
+                                                    "x5c",
+                                                    "x5t#S256"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "certificateRef": {
+                                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                                  "properties": {
+                                                    "group": {
+                                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name of the referenced credential",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "custom credential refs must set both group and kind",
+                                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                    }
+                                                  ]
+                                                },
+                                                "kid": {
+                                                  "description": "Optional JWS key ID header.",
+                                                  "type": "string"
+                                                },
+                                                "signingKeyRef": {
+                                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                                  "properties": {
+                                                    "group": {
+                                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name of the referenced credential",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "custom credential refs must set both group and kind",
+                                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "assertionAudience",
+                                                "signingKeyRef"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "certificateRef and certificateHeader must be set together",
+                                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                                }
+                                              ]
+                                            },
+                                            "secretRef": {
+                                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                              "properties": {
+                                                "group": {
+                                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "kind": {
+                                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "description": "Name of the referenced credential",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "custom credential refs must set both group and kind",
+                                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "clientId"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                            },
+                                            {
+                                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                            },
+                                            {
+                                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                            }
+                                          ]
+                                        },
+                                        "path": {
+                                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                          "pattern": "^/",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "backendRef",
+                                        "clientAuth"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "resourceAuthorizationServer": {
+                                      "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
+                                      "properties": {
+                                        "backendRef": {
+                                          "description": "Token endpoint backend.",
+                                          "properties": {
+                                            "group": {
+                                              "default": "",
+                                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                              "maxLength": 253,
+                                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "default": "Service",
+                                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                              "maxLength": 63,
+                                              "minLength": 1,
+                                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of the referent.",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                              "maxLength": 63,
+                                              "minLength": 1,
+                                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                              "format": "int32",
+                                              "maximum": 65535,
+                                              "minimum": 1,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "Must have port for Service reference",
+                                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                            }
+                                          ]
+                                        },
+                                        "clientAuth": {
+                                          "description": "Client authentication for the token endpoint.",
+                                          "properties": {
+                                            "clientId": {
+                                              "description": "Client ID sent to the token endpoint.",
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "method": {
+                                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                              "enum": [
+                                                "ClientSecretBasic",
+                                                "ClientSecretPost",
+                                                "PrivateKeyJwt"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "privateKeyJwt": {
+                                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                              "properties": {
+                                                "alg": {
+                                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                                  "enum": [
+                                                    "ES256",
+                                                    "ES384",
+                                                    "PS256",
+                                                    "RS256",
+                                                    "RS384",
+                                                    "RS512"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "assertionAudience": {
+                                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "certificateHeader": {
+                                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                                  "enum": [
+                                                    "x5c",
+                                                    "x5t#S256"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "certificateRef": {
+                                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                                  "properties": {
+                                                    "group": {
+                                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name of the referenced credential",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "custom credential refs must set both group and kind",
+                                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                    }
+                                                  ]
+                                                },
+                                                "kid": {
+                                                  "description": "Optional JWS key ID header.",
+                                                  "type": "string"
+                                                },
+                                                "signingKeyRef": {
+                                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                                  "properties": {
+                                                    "group": {
+                                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name of the referenced credential",
+                                                      "maxLength": 253,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "custom credential refs must set both group and kind",
+                                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "assertionAudience",
+                                                "signingKeyRef"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "certificateRef and certificateHeader must be set together",
+                                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                                }
+                                              ]
+                                            },
+                                            "secretRef": {
+                                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                              "properties": {
+                                                "group": {
+                                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "kind": {
+                                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "description": "Name of the referenced credential",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "custom credential refs must set both group and kind",
+                                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "clientId"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                            },
+                                            {
+                                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                            },
+                                            {
+                                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                            }
+                                          ]
+                                        },
+                                        "path": {
+                                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                          "pattern": "^/",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "backendRef",
+                                        "clientAuth"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "resources": {
+                                      "description": "Resources sent to the token endpoint.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "maxItems": 64,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "description": "Scopes sent to the token endpoint.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "maxItems": 64,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "subjectToken": {
+                                      "description": "Subject token sent to the identity provider. Defaults to an OpenID Connect\nID token read from the Authorization Bearer header.",
+                                      "properties": {
+                                        "source": {
+                                          "description": "Where to read the subject token. Defaults to the Authorization Bearer header.",
+                                          "properties": {
+                                            "cookie": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "expression": {
+                                              "description": "CEL expression that extracts the credential from the request.",
+                                              "maxLength": 16384,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "header": {
+                                              "properties": {
+                                                "name": {
+                                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                  "type": "string"
+                                                },
+                                                "prefix": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "queryParameter": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "audience",
+                                    "identityProvider",
+                                    "resourceAuthorizationServer"
+                                  ],
+                                  "type": "object"
                                 },
                                 "gcp": {
                                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -4202,18 +4218,24 @@
                                       "type": "string"
                                     },
                                     "secretRef": {
-                                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                      "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                       "properties": {
                                         "group": {
-                                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                          "maxLength": 253,
+                                          "minLength": 1,
                                           "type": "string"
                                         },
                                         "kind": {
-                                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                           "type": "string"
                                         },
                                         "name": {
-                                          "description": "The name of the referenced credential.",
+                                          "description": "Name of the referenced credential",
                                           "maxLength": 253,
                                           "minLength": 1,
                                           "type": "string"
@@ -4229,8 +4251,7 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ],
-                                      "additionalProperties": false
+                                      ]
                                     },
                                     "type": {
                                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -4247,8 +4268,7 @@
                                       "message": "audience is only valid with IdToken",
                                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 },
                                 "key": {
                                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -4256,7 +4276,7 @@
                                   "type": "string"
                                 },
                                 "location": {
-                                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.",
                                   "properties": {
                                     "cookie": {
                                       "properties": {
@@ -4269,13 +4289,12 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "header": {
                                       "properties": {
                                         "name": {
-                                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                           "maxLength": 256,
                                           "minLength": 1,
                                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -4290,8 +4309,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "queryParameter": {
                                       "properties": {
@@ -4304,8 +4322,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     }
                                   },
                                   "type": "object",
@@ -4314,26 +4331,599 @@
                                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                     }
+                                  ]
+                                },
+                                "oauthTokenExchange": {
+                                  "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
+                                  "properties": {
+                                    "actorToken": {
+                                      "description": "RFC 8693 delegation actor token. TokenExchange grant only.",
+                                      "properties": {
+                                        "mayAct": {
+                                          "description": "may_act claim validation mode. When omitted, may_act is not enforced.",
+                                          "enum": [
+                                            "Required"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "source": {
+                                          "description": "Where to read the actor token. Actor tokens have no default source.",
+                                          "properties": {
+                                            "cookie": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "expression": {
+                                              "description": "CEL expression that extracts the credential from the request.",
+                                              "maxLength": 16384,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "header": {
+                                              "properties": {
+                                                "name": {
+                                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                  "type": "string"
+                                                },
+                                                "prefix": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "queryParameter": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                            }
+                                          ]
+                                        },
+                                        "tokenType": {
+                                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "source"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "mayAct Required requires tokenType Jwt",
+                                          "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
+                                        }
+                                      ]
+                                    },
+                                    "additionalParams": {
+                                      "additionalProperties": {
+                                        "description": "A Common Expression Language (CEL) expression.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "description": "Extra form params; values are CEL expressions over the incoming request.",
+                                      "maxProperties": 64,
+                                      "type": "object"
+                                    },
+                                    "audiences": {
+                                      "description": "Audiences sent to the token endpoint.",
+                                      "items": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "maxItems": 64,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "backendRef": {
+                                      "description": "RFC 8693 token endpoint backend.",
+                                      "properties": {
+                                        "group": {
+                                          "default": "",
+                                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                          "maxLength": 253,
+                                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "default": "Service",
+                                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of the referent.",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                          "maxLength": 63,
+                                          "minLength": 1,
+                                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                          "format": "int32",
+                                          "maximum": 65535,
+                                          "minimum": 1,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "Must have port for Service reference",
+                                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                        }
+                                      ]
+                                    },
+                                    "cache": {
+                                      "description": "Response cache configuration.",
+                                      "properties": {
+                                        "inMemory": {
+                                          "properties": {
+                                            "defaultTtl": {
+                                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                                              "type": "string"
+                                            },
+                                            "maxEntries": {
+                                              "description": "Default 8192; 0 disables the cache.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "clientAuth": {
+                                      "description": "Client authentication for the token endpoint. When unset, none is sent.",
+                                      "properties": {
+                                        "clientId": {
+                                          "description": "Client ID sent to the token endpoint.",
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "method": {
+                                          "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                          "enum": [
+                                            "ClientSecretBasic",
+                                            "ClientSecretPost",
+                                            "PrivateKeyJwt"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "privateKeyJwt": {
+                                          "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                          "properties": {
+                                            "alg": {
+                                              "description": "JWS signing algorithm. Defaults to RS256.",
+                                              "enum": [
+                                                "ES256",
+                                                "ES384",
+                                                "PS256",
+                                                "RS256",
+                                                "RS384",
+                                                "RS512"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "assertionAudience": {
+                                              "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "certificateHeader": {
+                                              "description": "JWS certificate header. Required when certificateRef is set.",
+                                              "enum": [
+                                                "x5c",
+                                                "x5t#S256"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "certificateRef": {
+                                              "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                              "properties": {
+                                                "group": {
+                                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "kind": {
+                                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "description": "Name of the referenced credential",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "custom credential refs must set both group and kind",
+                                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                }
+                                              ]
+                                            },
+                                            "kid": {
+                                              "description": "Optional JWS key ID header.",
+                                              "type": "string"
+                                            },
+                                            "signingKeyRef": {
+                                              "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                              "properties": {
+                                                "group": {
+                                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "kind": {
+                                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "description": "Name of the referenced credential",
+                                                  "maxLength": 253,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "custom credential refs must set both group and kind",
+                                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "assertionAudience",
+                                            "signingKeyRef"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "certificateRef and certificateHeader must be set together",
+                                              "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                            }
+                                          ]
+                                        },
+                                        "secretRef": {
+                                          "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                          "properties": {
+                                            "group": {
+                                              "description": "API group of the referenced credential; empty selects the core API group",
+                                              "type": "string"
+                                            },
+                                            "key": {
+                                              "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the referenced credential",
+                                              "maxLength": 253,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "custom credential refs must set both group and kind",
+                                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "clientId"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                          "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                        },
+                                        {
+                                          "message": "secretRef is not valid with method PrivateKeyJwt",
+                                          "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                        },
+                                        {
+                                          "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                          "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                        }
+                                      ]
+                                    },
+                                    "grantType": {
+                                      "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
+                                      "enum": [
+                                        "JwtBearer",
+                                        "TokenExchange"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "location": {
+                                      "description": "Where the exchanged token is written to the backend request.\nDefaults to Authorization: Bearer.",
+                                      "properties": {
+                                        "cookie": {
+                                          "properties": {
+                                            "name": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                              "type": "string"
+                                            },
+                                            "prefix": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "queryParameter": {
+                                          "properties": {
+                                            "name": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                          "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                        }
+                                      ]
+                                    },
+                                    "path": {
+                                      "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                      "pattern": "^/",
+                                      "type": "string"
+                                    },
+                                    "requestedTokenType": {
+                                      "description": "RFC 8693 requested_token_type. Unlike subject/actor token types, only the\nbuilt-in values may be requested; custom URIs are not supported here.",
+                                      "enum": [
+                                        "AccessToken",
+                                        "Jwt",
+                                        "IdToken",
+                                        "IdJag"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "description": "Resources sent to the token endpoint.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "maxItems": 64,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "description": "Scopes sent to the token endpoint.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "maxItems": 64,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "subjectToken": {
+                                      "description": "Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.\nThe token type may be a built-in value or a custom absolute URI for providers\nthat support custom token exchange profiles.",
+                                      "properties": {
+                                        "source": {
+                                          "description": "Where to read the token. CEL `expression` variant is permitted.",
+                                          "properties": {
+                                            "cookie": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "expression": {
+                                              "description": "CEL expression that extracts the credential from the request.",
+                                              "maxLength": 16384,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "header": {
+                                              "properties": {
+                                                "name": {
+                                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                  "type": "string"
+                                                },
+                                                "prefix": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "queryParameter": {
+                                              "properties": {
+                                                "name": {
+                                                  "maxLength": 256,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                            }
+                                          ]
+                                        },
+                                        "tokenType": {
+                                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "backendRef"
                                   ],
-                                  "additionalProperties": false
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "actorToken is only valid with TokenExchange grantType",
+                                      "rule": "!(has(self.actorToken) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                                    },
+                                    {
+                                      "message": "requestedTokenType is only valid with TokenExchange grantType",
+                                      "rule": "!(has(self.requestedTokenType) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                                    },
+                                    {
+                                      "message": "requestedTokenType IdJag is only supported by crossAppAccess",
+                                      "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
+                                    }
+                                  ]
                                 },
                                 "passthrough": {
-                                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                  "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
                                   "type": "object"
                                 },
                                 "secretRef": {
-                                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                  "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                   "properties": {
                                     "group": {
-                                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
                                       "type": "string"
                                     },
                                     "kind": {
-                                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                       "type": "string"
                                     },
                                     "name": {
-                                      "description": "The name of the referenced credential.",
+                                      "description": "Name of the referenced credential",
                                       "maxLength": 253,
                                       "minLength": 1,
                                       "type": "string"
@@ -4349,22 +4939,24 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 }
                               },
                               "type": "object",
                               "x-kubernetes-validations": [
                                 {
-                                  "message": "location may only be set for key or passthrough auth",
+                                  "message": "must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess (credentials may be combined with a primary auth kind)",
+                                  "rule": "has(self.credentials) || has(self.key) || has(self.secretRef) || has(self.passthrough) || has(self.aws) || has(self.azure) || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)"
+                                },
+                                {
+                                  "message": "location may only be set for key, secretRef, or passthrough auth",
                                   "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
                                 },
                                 {
-                                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                  "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
+                                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "health": {
                               "description": "Settings for passive and active health checking.",
@@ -4381,6 +4973,7 @@
                                     "duration": {
                                       "default": "3s",
                                       "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                                      "maxLength": 32,
                                       "type": "string",
                                       "x-kubernetes-validations": [
                                         {
@@ -4394,7 +4987,7 @@
                                       ]
                                     },
                                     "healthThreshold": {
-                                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                                      "description": "EWMA health score threshold, from 0 to 100. When set, a backend is evicted\nonly if its computed health drops below this value after an unhealthy\nresponse (e.g. 50 evicts when EWMA health falls below 50%). Unlike\nconsecutiveFailures, this sliding-window average lets a single success delay\neviction. If both are set, either condition evicts; if neither, a single\nunhealthy response evicts.",
                                       "format": "int32",
                                       "maximum": 100,
                                       "minimum": 0,
@@ -4408,8 +5001,7 @@
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "unhealthyCondition": {
                                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -4418,14 +5010,14 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "http": {
-                              "description": "Settings for managing HTTP requests to the backend.",
+                              "description": "Settings for managing HTTP requests to the backend",
                               "properties": {
                                 "requestTimeout": {
                                   "description": "Deadline for receiving a response from the backend.",
+                                  "maxLength": 32,
                                   "type": "string",
                                   "x-kubernetes-validations": [
                                     {
@@ -4439,7 +5031,7 @@
                                   ]
                                 },
                                 "version": {
-                                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                  "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                   "enum": [
                                     "HTTP1",
                                     "HTTP2"
@@ -4447,14 +5039,14 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "tcp": {
-                              "description": "Settings for managing TCP connections to the backend.",
+                              "description": "Settings for managing TCP connections to the backend",
                               "properties": {
                                 "connectTimeout": {
                                   "description": "Deadline for establishing a connection to\nthe destination.",
+                                  "maxLength": 32,
                                   "type": "string",
                                   "x-kubernetes-validations": [
                                     {
@@ -4472,6 +5064,7 @@
                                   "properties": {
                                     "interval": {
                                       "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                      "maxLength": 32,
                                       "type": "string",
                                       "x-kubernetes-validations": [
                                         {
@@ -4493,6 +5086,7 @@
                                     },
                                     "time": {
                                       "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                      "maxLength": 32,
                                       "type": "string",
                                       "x-kubernetes-validations": [
                                         {
@@ -4506,15 +5100,13 @@
                                       ]
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "tls": {
-                              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                              "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                               "properties": {
                                 "alpnProtocols": {
                                   "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -4534,20 +5126,19 @@
                                     "properties": {
                                       "name": {
                                         "default": "",
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "description": "Name of the referent",
                                         "type": "string"
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "maxItems": 1,
                                   "type": "array",
                                   "x-kubernetes-list-type": "atomic"
                                 },
                                 "insecureSkipVerify": {
-                                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                  "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                   "enum": [
                                     "All",
                                     "Hostname"
@@ -4568,20 +5159,20 @@
                                   "type": "array"
                                 },
                                 "mtlsCertificateRef": {
-                                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                  "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                   "items": {
-                                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                    "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                     "properties": {
                                       "group": {
-                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "description": "API group of the referenced credential; empty selects the core API group",
                                         "type": "string"
                                       },
                                       "kind": {
-                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                         "type": "string"
                                       },
                                       "name": {
-                                        "description": "The name of the referenced credential.",
+                                        "description": "Name of the referenced credential",
                                         "maxLength": 253,
                                         "minLength": 1,
                                         "type": "string"
@@ -4597,8 +5188,7 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "maxItems": 1,
                                   "type": "array",
@@ -4637,8 +5227,7 @@
                                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "transformation": {
                               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -4674,8 +5263,7 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -4751,8 +5339,7 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -4769,8 +5356,7 @@
                                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 },
                                 "response": {
                                   "description": "Response transformation settings.",
@@ -4803,8 +5389,7 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -4880,8 +5465,7 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -4898,8 +5482,7 @@
                                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 }
                               },
                               "type": "object",
@@ -4908,25 +5491,24 @@
                                   "message": "at least one of the fields in [request response] must be set",
                                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "tunnel": {
-                              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                              "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                               "properties": {
                                 "backendRef": {
                                   "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                   "properties": {
                                     "group": {
                                       "default": "",
-                                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                       "maxLength": 253,
                                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                       "type": "string"
                                     },
                                     "kind": {
                                       "default": "Service",
-                                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                       "maxLength": 63,
                                       "minLength": 1,
                                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -4939,14 +5521,14 @@
                                       "type": "string"
                                     },
                                     "namespace": {
-                                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                       "maxLength": 63,
                                       "minLength": 1,
                                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                       "type": "string"
                                     },
                                     "port": {
-                                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                       "format": "int32",
                                       "maximum": 65535,
                                       "minimum": 1,
@@ -4962,15 +5544,13 @@
                                       "message": "Must have port for Service reference",
                                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 }
                               },
                               "required": [
                                 "backendRef"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -4979,8 +5559,7 @@
                               "message": "at least one of the fields in [ai auth health http tcp tls transformation tunnel] must be set",
                               "rule": "[has(self.ai),has(self.auth),has(self.health),has(self.http),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "port": {
                           "description": "Port to send requests to.",
@@ -5015,8 +5594,7 @@
                           "required": [
                             "projectId"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
@@ -5048,8 +5626,7 @@
                           "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
                           "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "maxItems": 16,
                     "minItems": 1,
@@ -5065,8 +5642,7 @@
                 "required": [
                   "providers"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "maxItems": 8,
               "minItems": 1,
@@ -5085,8 +5661,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "azure": {
                   "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
@@ -5134,8 +5709,7 @@
                       "message": "projectName is required when resourceType is Foundry",
                       "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "azureopenai": {
                   "description": "Azure OpenAI provider settings.",
@@ -5168,8 +5742,7 @@
                       "message": "deploymentName is required for this apiVersion",
                       "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "bedrock": {
                   "description": "Bedrock provider settings.",
@@ -5194,8 +5767,7 @@
                         "identifier",
                         "version"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "model": {
                       "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
@@ -5212,8 +5784,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "custom": {
                   "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
@@ -5259,8 +5830,7 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "formats": {
                       "description": "Provider-native API formats this provider supports.",
@@ -5296,8 +5866,7 @@
                             "message": "path must start with /",
                             "rule": "!has(self.path) || self.path.startsWith('/')"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 6,
                       "minItems": 1,
@@ -5323,8 +5892,7 @@
                       "message": "custom provider backendRef may target only Service or InferencePool",
                       "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "gemini": {
                   "description": "Gemini provider settings.",
@@ -5336,8 +5904,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "host": {
                   "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
@@ -5355,8 +5922,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "path": {
                   "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
@@ -5403,8 +5969,7 @@
                   "required": [
                     "projectId"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -5433,8 +5998,7 @@
                   "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
                   "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             }
           },
           "type": "object",
@@ -5443,8 +6007,7 @@
               "message": "exactly one of the fields in [provider groups] must be set",
               "rule": "[has(self.provider),has(self.groups)].filter(x,x==true).size() == 1"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "aws": {
           "description": "AWS service backend, such as AgentCore.",
@@ -5464,8 +6027,7 @@
               "required": [
                 "agentRuntimeArn"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
           "type": "object",
@@ -5474,8 +6036,7 @@
               "message": "exactly one of the fields in [agentCore] must be set",
               "rule": "[has(self.agentCore)].filter(x,x==true).size() == 1"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "dynamicForwardProxy": {
           "description": "Dynamically sends requests to the destination based on the incoming\nrequest HTTP host header, or TLS SNI for TLS traffic.\n\nWarning: this backend type can send requests to arbitrary destinations. Proper\naccess controls must be put in place when using this backend type.",
@@ -5489,6 +6050,15 @@
               "enum": [
                 "FailClosed",
                 "FailOpen"
+              ],
+              "type": "string"
+            },
+            "prefixMode": {
+              "description": "How tool and prompt names are prefixed with the target name. Resource URIs\nalways retain target routing information when multiplexing and are unaffected.\n`Conditional` (default) prefixes only when there are multiple targets.\n`Always` prefixes even with a single target. `Never` exposes unprefixed\nnames and routes calls by looking up which target serves the name;\nnames must be unique across targets.",
+              "enum": [
+                "Always",
+                "Conditional",
+                "Never"
               ],
               "type": "string"
             },
@@ -5544,8 +6114,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -5559,8 +6128,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "services": {
                         "description": "`services` is the label selector for which `Service` resources should be\nselected.",
@@ -5591,8 +6159,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -5606,8 +6173,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -5616,8 +6182,7 @@
                         "message": "at least one of the fields in [namespaces services] must be set",
                         "rule": "[has(self.namespaces),has(self.services)].filter(x,x==true).size() >= 1"
                       }
-                    ],
-                    "additionalProperties": false
+                    ]
                   },
                   "static": {
                     "description": "Static MCP destination. When connecting to\nin-cluster `Service` resources, it is recommended to use `selector`\ninstead.",
@@ -5627,13 +6192,12 @@
                         "properties": {
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "description": "Name of the referent",
                             "type": "string"
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "host": {
                         "description": "Hostname or IP address of the MCP target.",
@@ -5651,7 +6215,7 @@
                         "description": "Policies for communicating with this backend.\nPolicies may also be set in `AgentgatewayPolicy`, or in the top-level\n`AgentgatewayBackend`. Policies are merged on a field-level basis, with\norder: `AgentgatewayPolicy` < `AgentgatewayBackend` < `AgentgatewayBackend` MCP (this field).\nThis field may only be used with host-based static targets, not\n`backendRef`.",
                         "properties": {
                           "auth": {
-                            "description": "Settings for managing authentication to the backend.",
+                            "description": "Settings for managing authentication to the backend",
                             "properties": {
                               "aws": {
                                 "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
@@ -5664,27 +6228,90 @@
                                         "minLength": 1,
                                         "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                         "type": "string"
+                                      },
+                                      "sessionName": {
+                                        "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                        "pattern": "^[\\w+=,.@-]{2,64}$",
+                                        "type": "string"
+                                      },
+                                      "sessionNameExpression": {
+                                        "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "tags": {
+                                        "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                        "items": {
+                                          "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                          "properties": {
+                                            "expression": {
+                                              "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                              "maxLength": 16384,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "key": {
+                                              "description": "Key is the tag key.",
+                                              "maxLength": 128,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is a static tag value.",
+                                              "maxLength": 256,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-validations": [
+                                            {
+                                              "message": "exactly one of value or expression must be set",
+                                              "rule": "has(self.value) != has(self.expression)"
+                                            }
+                                          ]
+                                        },
+                                        "maxItems": 50,
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                          "key"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
                                       }
                                     },
                                     "required": [
                                       "roleArn"
                                     ],
                                     "type": "object",
-                                    "additionalProperties": false
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                        "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "region": {
+                                    "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
                                   },
                                   "secretRef": {
-                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                    "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                     "properties": {
                                       "group": {
-                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "description": "API group of the referenced credential; empty selects the core API group",
                                         "type": "string"
                                       },
                                       "kind": {
-                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                         "type": "string"
                                       },
                                       "name": {
-                                        "description": "The name of the referenced credential.",
+                                        "description": "Name of the referenced credential",
                                         "maxLength": 253,
                                         "minLength": 1,
                                         "type": "string"
@@ -5700,8 +6327,7 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "serviceName": {
                                     "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -5716,8 +6342,7 @@
                                     "message": "secretRef and assumeRole are mutually exclusive",
                                     "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "azure": {
                                 "description": "Azure authentication method for the backend.",
@@ -5740,22 +6365,21 @@
                                       "objectId",
                                       "resourceId"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "secretRef": {
-                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                    "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
                                     "properties": {
                                       "group": {
-                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "description": "API group of the referenced credential; empty selects the core API group",
                                         "type": "string"
                                       },
                                       "kind": {
-                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                         "type": "string"
                                       },
                                       "name": {
-                                        "description": "The name of the referenced credential.",
+                                        "description": "Name of the referenced credential",
                                         "maxLength": 253,
                                         "minLength": 1,
                                         "type": "string"
@@ -5771,12 +6395,766 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
+                                  },
+                                  "workloadIdentity": {
+                                    "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
+                                    "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
+                                  }
+                                ]
+                              },
+                              "credentials": {
+                                "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
+                                "items": {
+                                  "description": "BackendAuthCredential specifies one additional credential to inject on the\nbackend request.",
+                                  "properties": {
+                                    "location": {
+                                      "description": "Where the credential is inserted on the backend request.",
+                                      "properties": {
+                                        "cookie": {
+                                          "properties": {
+                                            "name": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                              "type": "string"
+                                            },
+                                            "prefix": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "queryParameter": {
+                                          "properties": {
+                                            "name": {
+                                              "maxLength": 256,
+                                              "minLength": 1,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                          "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                        }
+                                      ]
+                                    },
+                                    "secretRef": {
+                                      "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "location",
+                                    "secretRef"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 8,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "crossAppAccess": {
+                                "description": "Cross App Access (Identity Assertion / ID-JAG) authentication.",
+                                "properties": {
+                                  "audience": {
+                                    "description": "Identifier of the resource authorization server. The issued ID-JAG is bound to this audience.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "cache": {
+                                    "description": "Response cache configuration.",
+                                    "properties": {
+                                      "inMemory": {
+                                        "properties": {
+                                          "defaultTtl": {
+                                            "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                                            "type": "string"
+                                          },
+                                          "maxEntries": {
+                                            "description": "Default 8192; 0 disables the cache.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "identityProvider": {
+                                    "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Token endpoint backend.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      },
+                                      "clientAuth": {
+                                        "description": "Client authentication for the token endpoint.",
+                                        "properties": {
+                                          "clientId": {
+                                            "description": "Client ID sent to the token endpoint.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "method": {
+                                            "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                            "enum": [
+                                              "ClientSecretBasic",
+                                              "ClientSecretPost",
+                                              "PrivateKeyJwt"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "privateKeyJwt": {
+                                            "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                            "properties": {
+                                              "alg": {
+                                                "description": "JWS signing algorithm. Defaults to RS256.",
+                                                "enum": [
+                                                  "ES256",
+                                                  "ES384",
+                                                  "PS256",
+                                                  "RS256",
+                                                  "RS384",
+                                                  "RS512"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "assertionAudience": {
+                                                "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "certificateHeader": {
+                                                "description": "JWS certificate header. Required when certificateRef is set.",
+                                                "enum": [
+                                                  "x5c",
+                                                  "x5t#S256"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "certificateRef": {
+                                                "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                                "properties": {
+                                                  "group": {
+                                                    "description": "API group of the referenced credential; empty selects the core API group",
+                                                    "type": "string"
+                                                  },
+                                                  "key": {
+                                                    "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referenced credential",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "custom credential refs must set both group and kind",
+                                                    "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                  }
+                                                ]
+                                              },
+                                              "kid": {
+                                                "description": "Optional JWS key ID header.",
+                                                "type": "string"
+                                              },
+                                              "signingKeyRef": {
+                                                "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                                "properties": {
+                                                  "group": {
+                                                    "description": "API group of the referenced credential; empty selects the core API group",
+                                                    "type": "string"
+                                                  },
+                                                  "key": {
+                                                    "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referenced credential",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "custom credential refs must set both group and kind",
+                                                    "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "assertionAudience",
+                                              "signingKeyRef"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "certificateRef and certificateHeader must be set together",
+                                                "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                              }
+                                            ]
+                                          },
+                                          "secretRef": {
+                                            "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name of the referenced credential",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "clientId"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                            "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                          },
+                                          {
+                                            "message": "secretRef is not valid with method PrivateKeyJwt",
+                                            "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                          },
+                                          {
+                                            "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                            "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                          }
+                                        ]
+                                      },
+                                      "path": {
+                                        "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                        "pattern": "^/",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef",
+                                      "clientAuth"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "resourceAuthorizationServer": {
+                                    "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "Token endpoint backend.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      },
+                                      "clientAuth": {
+                                        "description": "Client authentication for the token endpoint.",
+                                        "properties": {
+                                          "clientId": {
+                                            "description": "Client ID sent to the token endpoint.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "method": {
+                                            "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                            "enum": [
+                                              "ClientSecretBasic",
+                                              "ClientSecretPost",
+                                              "PrivateKeyJwt"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "privateKeyJwt": {
+                                            "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                            "properties": {
+                                              "alg": {
+                                                "description": "JWS signing algorithm. Defaults to RS256.",
+                                                "enum": [
+                                                  "ES256",
+                                                  "ES384",
+                                                  "PS256",
+                                                  "RS256",
+                                                  "RS384",
+                                                  "RS512"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "assertionAudience": {
+                                                "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "certificateHeader": {
+                                                "description": "JWS certificate header. Required when certificateRef is set.",
+                                                "enum": [
+                                                  "x5c",
+                                                  "x5t#S256"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "certificateRef": {
+                                                "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                                "properties": {
+                                                  "group": {
+                                                    "description": "API group of the referenced credential; empty selects the core API group",
+                                                    "type": "string"
+                                                  },
+                                                  "key": {
+                                                    "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referenced credential",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "custom credential refs must set both group and kind",
+                                                    "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                  }
+                                                ]
+                                              },
+                                              "kid": {
+                                                "description": "Optional JWS key ID header.",
+                                                "type": "string"
+                                              },
+                                              "signingKeyRef": {
+                                                "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                                "properties": {
+                                                  "group": {
+                                                    "description": "API group of the referenced credential; empty selects the core API group",
+                                                    "type": "string"
+                                                  },
+                                                  "key": {
+                                                    "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referenced credential",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "custom credential refs must set both group and kind",
+                                                    "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "assertionAudience",
+                                              "signingKeyRef"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "certificateRef and certificateHeader must be set together",
+                                                "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                              }
+                                            ]
+                                          },
+                                          "secretRef": {
+                                            "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name of the referenced credential",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "clientId"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                            "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                          },
+                                          {
+                                            "message": "secretRef is not valid with method PrivateKeyJwt",
+                                            "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                          },
+                                          {
+                                            "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                            "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                          }
+                                        ]
+                                      },
+                                      "path": {
+                                        "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                        "pattern": "^/",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef",
+                                      "clientAuth"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "resources": {
+                                    "description": "Resources sent to the token endpoint.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "maxItems": 64,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "description": "Scopes sent to the token endpoint.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "maxItems": 64,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "subjectToken": {
+                                    "description": "Subject token sent to the identity provider. Defaults to an OpenID Connect\nID token read from the Authorization Bearer header.",
+                                    "properties": {
+                                      "source": {
+                                        "description": "Where to read the subject token. Defaults to the Authorization Bearer header.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "expression": {
+                                            "description": "CEL expression that extracts the credential from the request.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "audience",
+                                  "identityProvider",
+                                  "resourceAuthorizationServer"
+                                ],
+                                "type": "object"
                               },
                               "gcp": {
                                 "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -5788,18 +7166,24 @@
                                     "type": "string"
                                   },
                                   "secretRef": {
-                                    "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                    "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                     "properties": {
                                       "group": {
-                                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                        "description": "API group of the referenced credential; empty selects the core API group",
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                        "maxLength": 253,
+                                        "minLength": 1,
                                         "type": "string"
                                       },
                                       "kind": {
-                                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                         "type": "string"
                                       },
                                       "name": {
-                                        "description": "The name of the referenced credential.",
+                                        "description": "Name of the referenced credential",
                                         "maxLength": 253,
                                         "minLength": 1,
                                         "type": "string"
@@ -5815,8 +7199,7 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "type": {
                                     "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -5833,8 +7216,7 @@
                                     "message": "audience is only valid with IdToken",
                                     "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "key": {
                                 "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -5842,7 +7224,7 @@
                                 "type": "string"
                               },
                               "location": {
-                                "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.",
                                 "properties": {
                                   "cookie": {
                                     "properties": {
@@ -5855,13 +7237,12 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "header": {
                                     "properties": {
                                       "name": {
-                                        "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                        "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                         "maxLength": 256,
                                         "minLength": 1,
                                         "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -5876,8 +7257,7 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "queryParameter": {
                                     "properties": {
@@ -5890,8 +7270,7 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -5900,26 +7279,599 @@
                                     "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                     "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                   }
+                                ]
+                              },
+                              "oauthTokenExchange": {
+                                "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
+                                "properties": {
+                                  "actorToken": {
+                                    "description": "RFC 8693 delegation actor token. TokenExchange grant only.",
+                                    "properties": {
+                                      "mayAct": {
+                                        "description": "may_act claim validation mode. When omitted, may_act is not enforced.",
+                                        "enum": [
+                                          "Required"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "description": "Where to read the actor token. Actor tokens have no default source.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "expression": {
+                                            "description": "CEL expression that extracts the credential from the request.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "tokenType": {
+                                        "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "source"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "mayAct Required requires tokenType Jwt",
+                                        "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
+                                      }
+                                    ]
+                                  },
+                                  "additionalParams": {
+                                    "additionalProperties": {
+                                      "description": "A Common Expression Language (CEL) expression.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "description": "Extra form params; values are CEL expressions over the incoming request.",
+                                    "maxProperties": 64,
+                                    "type": "object"
+                                  },
+                                  "audiences": {
+                                    "description": "Audiences sent to the token endpoint.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 64,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "backendRef": {
+                                    "description": "RFC 8693 token endpoint backend.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ]
+                                  },
+                                  "cache": {
+                                    "description": "Response cache configuration.",
+                                    "properties": {
+                                      "inMemory": {
+                                        "properties": {
+                                          "defaultTtl": {
+                                            "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                                            "type": "string"
+                                          },
+                                          "maxEntries": {
+                                            "description": "Default 8192; 0 disables the cache.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "clientAuth": {
+                                    "description": "Client authentication for the token endpoint. When unset, none is sent.",
+                                    "properties": {
+                                      "clientId": {
+                                        "description": "Client ID sent to the token endpoint.",
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                                        "enum": [
+                                          "ClientSecretBasic",
+                                          "ClientSecretPost",
+                                          "PrivateKeyJwt"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "privateKeyJwt": {
+                                        "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                                        "properties": {
+                                          "alg": {
+                                            "description": "JWS signing algorithm. Defaults to RS256.",
+                                            "enum": [
+                                              "ES256",
+                                              "ES384",
+                                              "PS256",
+                                              "RS256",
+                                              "RS384",
+                                              "RS512"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "assertionAudience": {
+                                            "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "certificateHeader": {
+                                            "description": "JWS certificate header. Required when certificateRef is set.",
+                                            "enum": [
+                                              "x5c",
+                                              "x5t#S256"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "certificateRef": {
+                                            "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name of the referenced credential",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ]
+                                          },
+                                          "kid": {
+                                            "description": "Optional JWS key ID header.",
+                                            "type": "string"
+                                          },
+                                          "signingKeyRef": {
+                                            "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                            "properties": {
+                                              "group": {
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "description": "Name of the referenced credential",
+                                                "maxLength": 253,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "custom credential refs must set both group and kind",
+                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "assertionAudience",
+                                          "signingKeyRef"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "certificateRef and certificateHeader must be set together",
+                                            "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                          }
+                                        ]
+                                      },
+                                      "secretRef": {
+                                        "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "clientId"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                                        "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                                      },
+                                      {
+                                        "message": "secretRef is not valid with method PrivateKeyJwt",
+                                        "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                                      },
+                                      {
+                                        "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                                        "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                                      }
+                                    ]
+                                  },
+                                  "grantType": {
+                                    "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
+                                    "enum": [
+                                      "JwtBearer",
+                                      "TokenExchange"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "description": "Where the exchanged token is written to the backend request.\nDefaults to Authorization: Bearer.",
+                                    "properties": {
+                                      "cookie": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "header": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "prefix": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "queryParameter": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                        "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "path": {
+                                    "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                                    "pattern": "^/",
+                                    "type": "string"
+                                  },
+                                  "requestedTokenType": {
+                                    "description": "RFC 8693 requested_token_type. Unlike subject/actor token types, only the\nbuilt-in values may be requested; custom URIs are not supported here.",
+                                    "enum": [
+                                      "AccessToken",
+                                      "Jwt",
+                                      "IdToken",
+                                      "IdJag"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources sent to the token endpoint.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "maxItems": 64,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "description": "Scopes sent to the token endpoint.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "maxItems": 64,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "subjectToken": {
+                                    "description": "Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.\nThe token type may be a built-in value or a custom absolute URI for providers\nthat support custom token exchange profiles.",
+                                    "properties": {
+                                      "source": {
+                                        "description": "Where to read the token. CEL `expression` variant is permitted.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "expression": {
+                                            "description": "CEL expression that extracts the credential from the request.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "tokenType": {
+                                        "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
                                 ],
-                                "additionalProperties": false
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "actorToken is only valid with TokenExchange grantType",
+                                    "rule": "!(has(self.actorToken) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                                  },
+                                  {
+                                    "message": "requestedTokenType is only valid with TokenExchange grantType",
+                                    "rule": "!(has(self.requestedTokenType) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                                  },
+                                  {
+                                    "message": "requestedTokenType IdJag is only supported by crossAppAccess",
+                                    "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
+                                  }
+                                ]
                               },
                               "passthrough": {
-                                "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
                                 "type": "object"
                               },
                               "secretRef": {
-                                "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                 "properties": {
                                   "group": {
-                                    "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                    "description": "API group of the referenced credential; empty selects the core API group",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                    "maxLength": 253,
+                                    "minLength": 1,
                                     "type": "string"
                                   },
                                   "kind": {
-                                    "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                    "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                     "type": "string"
                                   },
                                   "name": {
-                                    "description": "The name of the referenced credential.",
+                                    "description": "Name of the referenced credential",
                                     "maxLength": 253,
                                     "minLength": 1,
                                     "type": "string"
@@ -5935,28 +7887,31 @@
                                     "message": "custom credential refs must set both group and kind",
                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               }
                             },
                             "type": "object",
                             "x-kubernetes-validations": [
                               {
-                                "message": "location may only be set for key or passthrough auth",
+                                "message": "must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess (credentials may be combined with a primary auth kind)",
+                                "rule": "has(self.credentials) || has(self.key) || has(self.secretRef) || has(self.passthrough) || has(self.aws) || has(self.azure) || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)"
+                              },
+                              {
+                                "message": "location may only be set for key, secretRef, or passthrough auth",
                                 "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
                               },
                               {
-                                "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
+                                "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "http": {
-                            "description": "Settings for managing HTTP requests to the backend.",
+                            "description": "Settings for managing HTTP requests to the backend",
                             "properties": {
                               "requestTimeout": {
                                 "description": "Deadline for receiving a response from the backend.",
+                                "maxLength": 32,
                                 "type": "string",
                                 "x-kubernetes-validations": [
                                   {
@@ -5970,7 +7925,7 @@
                                 ]
                               },
                               "version": {
-                                "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                 "enum": [
                                   "HTTP1",
                                   "HTTP2"
@@ -5978,14 +7933,14 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcp": {
-                            "description": "Settings for managing TCP connections to the backend.",
+                            "description": "Settings for managing TCP connections to the backend",
                             "properties": {
                               "connectTimeout": {
                                 "description": "Deadline for establishing a connection to\nthe destination.",
+                                "maxLength": 32,
                                 "type": "string",
                                 "x-kubernetes-validations": [
                                   {
@@ -6003,6 +7958,7 @@
                                 "properties": {
                                   "interval": {
                                     "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                    "maxLength": 32,
                                     "type": "string",
                                     "x-kubernetes-validations": [
                                       {
@@ -6024,6 +7980,7 @@
                                   },
                                   "time": {
                                     "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                    "maxLength": 32,
                                     "type": "string",
                                     "x-kubernetes-validations": [
                                       {
@@ -6037,15 +7994,13 @@
                                     ]
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tls": {
-                            "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                            "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                             "properties": {
                               "alpnProtocols": {
                                 "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -6065,20 +8020,19 @@
                                   "properties": {
                                     "name": {
                                       "default": "",
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "description": "Name of the referent",
                                       "type": "string"
                                     }
                                   },
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "maxItems": 1,
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
                               },
                               "insecureSkipVerify": {
-                                "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                 "enum": [
                                   "All",
                                   "Hostname"
@@ -6099,20 +8053,20 @@
                                 "type": "array"
                               },
                               "mtlsCertificateRef": {
-                                "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                 "items": {
-                                  "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                  "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                   "properties": {
                                     "group": {
-                                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                      "description": "API group of the referenced credential; empty selects the core API group",
                                       "type": "string"
                                     },
                                     "kind": {
-                                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                       "type": "string"
                                     },
                                     "name": {
-                                      "description": "The name of the referenced credential.",
+                                      "description": "Name of the referenced credential",
                                       "maxLength": 253,
                                       "minLength": 1,
                                       "type": "string"
@@ -6128,8 +8082,7 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ],
-                                  "additionalProperties": false
+                                  ]
                                 },
                                 "maxItems": 1,
                                 "type": "array",
@@ -6168,25 +8121,24 @@
                                 "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                 "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "tunnel": {
-                            "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                            "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                             "properties": {
                               "backendRef": {
                                 "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -6199,14 +8151,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -6222,19 +8174,16 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "port": {
                         "description": "Port number of the MCP target.",
@@ -6265,8 +8214,7 @@
                         "message": "exactly one of the fields in [host backendRef] must be set",
                         "rule": "[has(self.host),has(self.backendRef)].filter(x,x==true).size() == 1"
                       }
-                    ],
-                    "additionalProperties": false
+                    ]
                   }
                 },
                 "required": [
@@ -6278,8 +8226,7 @@
                     "message": "exactly one of the fields in [selector static] must be set",
                     "rule": "[has(self.selector),has(self.static)].filter(x,x==true).size() == 1"
                   }
-                ],
-                "additionalProperties": false
+                ]
               },
               "maxItems": 32,
               "minItems": 1,
@@ -6299,8 +8246,7 @@
           "required": [
             "targets"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "policies": {
           "description": "Policies for communicating with this backend. Policies may also be set\nwith AgentgatewayPolicy. Backend policies take precedence over policy\nresources when they set the same field.",
@@ -6314,16 +8260,9 @@
                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                     "properties": {
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       },
                       "value": {
@@ -6335,8 +8274,7 @@
                       "field",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -6356,16 +8294,9 @@
                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                     "properties": {
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       },
                       "value": {
@@ -6377,8 +8308,7 @@
                       "field",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -6405,8 +8335,7 @@
                           "content",
                           "role"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -6428,14 +8357,12 @@
                           "content",
                           "role"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "promptCaching": {
                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -6463,13 +8390,12 @@
                     },
                     "minTokens": {
                       "default": 1024,
-                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                       "minimum": 0,
                       "type": "integer"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "promptGuard": {
                   "description": "Guardrails for LLM requests and responses.",
@@ -6492,10 +8418,10 @@
                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                     "properties": {
                                       "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                         "properties": {
                                           "assumeRole": {
                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -6505,27 +8431,90 @@
                                                 "minLength": 1,
                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                 "type": "string"
+                                              },
+                                              "sessionName": {
+                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                "type": "string"
+                                              },
+                                              "sessionNameExpression": {
+                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                "maxLength": 16384,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "tags": {
+                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                "items": {
+                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                  "properties": {
+                                                    "expression": {
+                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                      "maxLength": 16384,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key is the tag key.",
+                                                      "maxLength": 128,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is a static tag value.",
+                                                      "maxLength": 256,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "exactly one of value or expression must be set",
+                                                      "rule": "has(self.value) != has(self.expression)"
+                                                    }
+                                                  ]
+                                                },
+                                                "maxItems": 50,
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                  "key"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
                                               }
                                             },
                                             "required": [
                                               "roleArn"
                                             ],
                                             "type": "object",
-                                            "additionalProperties": false
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                              }
+                                            ]
+                                          },
+                                          "region": {
+                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -6541,8 +8530,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -6557,133 +8545,15 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -6696,13 +8566,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -6717,8 +8586,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -6731,8 +8599,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -6741,26 +8608,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -6776,28 +8644,27 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                        "message": "location may only be set for key or secretRef auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                       },
                                       {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -6811,7 +8678,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -6819,14 +8686,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -6844,6 +8711,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -6865,6 +8733,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -6878,15 +8747,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -6906,20 +8773,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -6940,20 +8806,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -6969,8 +8835,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -7009,25 +8874,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -7040,14 +8904,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -7063,19 +8927,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -7095,8 +8962,7 @@
                               "region",
                               "version"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -7112,135 +8978,10 @@
                                 "description": "Policies for communicating with Google Model Armor.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to Google Model Armor.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
                                       "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                         "properties": {
                                           "audience": {
                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -7249,18 +8990,24 @@
                                             "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -7276,8 +9023,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -7294,130 +9040,23 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                        "maxLength": 2048,
-                                        "type": "string"
-                                      },
-                                      "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                        "properties": {
-                                          "cookie": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "header": {
-                                            "properties": {
-                                              "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                "type": "string"
-                                              },
-                                              "prefix": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "queryParameter": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
-                                      },
-                                      "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                        "properties": {
-                                          "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                            "type": "string"
-                                          },
-                                          "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                            "type": "string"
-                                          },
-                                          "name": {
-                                            "description": "The name of the referenced credential.",
-                                            "maxLength": 253,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "name"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "custom credential refs must set both group and kind",
-                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [gcp] must be set",
+                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -7431,7 +9070,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -7439,14 +9078,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -7464,6 +9103,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -7485,6 +9125,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -7498,15 +9139,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -7526,20 +9165,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -7560,20 +9198,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -7589,8 +9227,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -7629,25 +9266,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -7660,14 +9296,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -7683,19 +9319,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -7714,8 +9353,7 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "openAIModeration": {
                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -7728,198 +9366,15 @@
                                 "description": "Policies for communicating with OpenAI.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to OpenAI.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
                                       "key": {
                                         "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where backend credentials are inserted. Defaults to the `Authorization`\nheader with the `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -7932,13 +9387,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -7953,8 +9407,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -7967,8 +9420,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -7977,26 +9429,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -8012,28 +9465,23 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -8047,7 +9495,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -8055,14 +9503,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -8080,6 +9528,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -8101,6 +9550,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -8114,15 +9564,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -8142,20 +9590,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -8176,20 +9623,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -8205,8 +9652,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -8245,25 +9691,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -8276,14 +9721,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -8299,23 +9744,25 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -8354,8 +9801,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -8380,8 +9826,7 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "webhook": {
                             "description": "Webhook that receives requests for prompt guarding.",
@@ -8391,14 +9836,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -8411,14 +9856,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -8434,8 +9879,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -8451,7 +9895,7 @@
                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                   "properties": {
                                     "name": {
-                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                       "maxLength": 256,
                                       "minLength": 1,
                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -8459,7 +9903,7 @@
                                     },
                                     "type": {
                                       "default": "Exact",
-                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                       "enum": [
                                         "Exact",
                                         "RegularExpression"
@@ -8467,7 +9911,7 @@
                                       "type": "string"
                                     },
                                     "value": {
-                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "description": "Value of the HTTP header to match",
                                       "maxLength": 4096,
                                       "minLength": 1,
                                       "type": "string"
@@ -8477,17 +9921,26 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "CEL-computed headers to include in webhook requests.",
+                                "maxProperties": 64,
+                                "type": "object"
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -8496,8 +9949,7 @@
                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -8521,10 +9973,10 @@
                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                     "properties": {
                                       "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                         "properties": {
                                           "assumeRole": {
                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -8534,27 +9986,90 @@
                                                 "minLength": 1,
                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                 "type": "string"
+                                              },
+                                              "sessionName": {
+                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                "type": "string"
+                                              },
+                                              "sessionNameExpression": {
+                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                "maxLength": 16384,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "tags": {
+                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                "items": {
+                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                  "properties": {
+                                                    "expression": {
+                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                      "maxLength": 16384,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key is the tag key.",
+                                                      "maxLength": 128,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is a static tag value.",
+                                                      "maxLength": 256,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "exactly one of value or expression must be set",
+                                                      "rule": "has(self.value) != has(self.expression)"
+                                                    }
+                                                  ]
+                                                },
+                                                "maxItems": 50,
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                  "key"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
                                               }
                                             },
                                             "required": [
                                               "roleArn"
                                             ],
                                             "type": "object",
-                                            "additionalProperties": false
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                              }
+                                            ]
+                                          },
+                                          "region": {
+                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -8570,8 +10085,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -8586,133 +10100,15 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -8725,13 +10121,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -8746,8 +10141,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -8760,8 +10154,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -8770,26 +10163,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -8805,28 +10199,27 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                        "message": "location may only be set for key or secretRef auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                       },
                                       {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -8840,7 +10233,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -8848,14 +10241,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -8873,6 +10266,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -8894,6 +10288,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -8907,15 +10302,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -8935,20 +10328,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -8969,20 +10361,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -8998,8 +10390,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9038,25 +10429,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -9069,14 +10459,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -9092,19 +10482,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -9124,8 +10517,7 @@
                               "region",
                               "version"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -9141,135 +10533,10 @@
                                 "description": "Policies for communicating with Google Model Armor.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to Google Model Armor.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
                                       "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                         "properties": {
                                           "audience": {
                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -9278,18 +10545,24 @@
                                             "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -9305,8 +10578,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -9323,130 +10595,23 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                        "maxLength": 2048,
-                                        "type": "string"
-                                      },
-                                      "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                        "properties": {
-                                          "cookie": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "header": {
-                                            "properties": {
-                                              "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                "type": "string"
-                                              },
-                                              "prefix": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "queryParameter": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
-                                      },
-                                      "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                        "properties": {
-                                          "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                            "type": "string"
-                                          },
-                                          "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                            "type": "string"
-                                          },
-                                          "name": {
-                                            "description": "The name of the referenced credential.",
-                                            "maxLength": 253,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "name"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "custom credential refs must set both group and kind",
-                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [gcp] must be set",
+                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -9460,7 +10625,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -9468,14 +10633,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -9493,6 +10658,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -9514,6 +10680,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -9527,15 +10694,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -9555,20 +10720,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -9589,20 +10753,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -9618,8 +10782,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9658,25 +10821,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -9689,14 +10851,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -9712,19 +10874,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -9743,8 +10908,7 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -9783,8 +10947,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -9809,8 +10972,7 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "webhook": {
                             "description": "Webhook that receives responses for prompt guarding.",
@@ -9820,14 +10982,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -9840,14 +11002,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -9863,8 +11025,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -9880,7 +11041,7 @@
                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                   "properties": {
                                     "name": {
-                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                       "maxLength": 256,
                                       "minLength": 1,
                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -9888,7 +11049,7 @@
                                     },
                                     "type": {
                                       "default": "Exact",
-                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                       "enum": [
                                         "Exact",
                                         "RegularExpression"
@@ -9896,7 +11057,7 @@
                                       "type": "string"
                                     },
                                     "value": {
-                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "description": "Value of the HTTP header to match",
                                       "maxLength": 4096,
                                       "minLength": 1,
                                       "type": "string"
@@ -9906,17 +11067,26 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "CEL-computed headers to include in webhook requests.",
+                                "maxProperties": 64,
+                                "type": "object"
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -9925,8 +11095,7 @@
                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -9946,8 +11115,7 @@
                       "message": "at least one of the fields in [request response] must be set",
                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "routes": {
                   "additionalProperties": {
@@ -9981,16 +11149,9 @@
                         "type": "string"
                       },
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field to set.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       }
                     },
@@ -9998,8 +11159,7 @@
                       "expression",
                       "field"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -10012,11 +11172,10 @@
                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "auth": {
-              "description": "Settings for managing authentication to the backend.",
+              "description": "Settings for managing authentication to the backend",
               "properties": {
                 "aws": {
                   "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
@@ -10029,27 +11188,90 @@
                           "minLength": 1,
                           "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                           "type": "string"
+                        },
+                        "sessionName": {
+                          "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                          "pattern": "^[\\w+=,.@-]{2,64}$",
+                          "type": "string"
+                        },
+                        "sessionNameExpression": {
+                          "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                          "maxLength": 16384,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                          "items": {
+                            "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                            "properties": {
+                              "expression": {
+                                "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the tag key.",
+                                "maxLength": 128,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is a static tag value.",
+                                "maxLength": 256,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "exactly one of value or expression must be set",
+                                "rule": "has(self.value) != has(self.expression)"
+                              }
+                            ]
+                          },
+                          "maxItems": 50,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "key"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         }
                       },
                       "required": [
                         "roleArn"
                       ],
                       "type": "object",
-                      "additionalProperties": false
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                          "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                        }
+                      ]
+                    },
+                    "region": {
+                      "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -10065,8 +11287,7 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "serviceName": {
                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -10081,8 +11302,7 @@
                       "message": "secretRef and assumeRole are mutually exclusive",
                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "azure": {
                   "description": "Azure authentication method for the backend.",
@@ -10105,22 +11325,21 @@
                         "objectId",
                         "resourceId"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -10136,12 +11355,766 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
+                    },
+                    "workloadIdentity": {
+                      "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
-                  "additionalProperties": false
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
+                      "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
+                    }
+                  ]
+                },
+                "credentials": {
+                  "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
+                  "items": {
+                    "description": "BackendAuthCredential specifies one additional credential to inject on the\nbackend request.",
+                    "properties": {
+                      "location": {
+                        "description": "Where the credential is inserted on the backend request.",
+                        "properties": {
+                          "cookie": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "header": {
+                            "properties": {
+                              "name": {
+                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "prefix": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "queryParameter": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
+                        "properties": {
+                          "group": {
+                            "description": "API group of the referenced credential; empty selects the core API group",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referenced credential",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "custom credential refs must set both group and kind",
+                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "location",
+                      "secretRef"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "crossAppAccess": {
+                  "description": "Cross App Access (Identity Assertion / ID-JAG) authentication.",
+                  "properties": {
+                    "audience": {
+                      "description": "Identifier of the resource authorization server. The issued ID-JAG is bound to this audience.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "cache": {
+                      "description": "Response cache configuration.",
+                      "properties": {
+                        "inMemory": {
+                          "properties": {
+                            "defaultTtl": {
+                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                              "type": "string"
+                            },
+                            "maxEntries": {
+                              "description": "Default 8192; 0 disables the cache.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "identityProvider": {
+                      "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Token endpoint backend.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "clientAuth": {
+                          "description": "Client authentication for the token endpoint.",
+                          "properties": {
+                            "clientId": {
+                              "description": "Client ID sent to the token endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "method": {
+                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                              "enum": [
+                                "ClientSecretBasic",
+                                "ClientSecretPost",
+                                "PrivateKeyJwt"
+                              ],
+                              "type": "string"
+                            },
+                            "privateKeyJwt": {
+                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                              "properties": {
+                                "alg": {
+                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                  "enum": [
+                                    "ES256",
+                                    "ES384",
+                                    "PS256",
+                                    "RS256",
+                                    "RS384",
+                                    "RS512"
+                                  ],
+                                  "type": "string"
+                                },
+                                "assertionAudience": {
+                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "certificateHeader": {
+                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                  "enum": [
+                                    "x5c",
+                                    "x5t#S256"
+                                  ],
+                                  "type": "string"
+                                },
+                                "certificateRef": {
+                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                },
+                                "kid": {
+                                  "description": "Optional JWS key ID header.",
+                                  "type": "string"
+                                },
+                                "signingKeyRef": {
+                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assertionAudience",
+                                "signingKeyRef"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "certificateRef and certificateHeader must be set together",
+                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                }
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "clientId"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                            },
+                            {
+                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                            },
+                            {
+                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                            }
+                          ]
+                        },
+                        "path": {
+                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                          "pattern": "^/",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "clientAuth"
+                      ],
+                      "type": "object"
+                    },
+                    "resourceAuthorizationServer": {
+                      "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Token endpoint backend.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "clientAuth": {
+                          "description": "Client authentication for the token endpoint.",
+                          "properties": {
+                            "clientId": {
+                              "description": "Client ID sent to the token endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "method": {
+                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                              "enum": [
+                                "ClientSecretBasic",
+                                "ClientSecretPost",
+                                "PrivateKeyJwt"
+                              ],
+                              "type": "string"
+                            },
+                            "privateKeyJwt": {
+                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                              "properties": {
+                                "alg": {
+                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                  "enum": [
+                                    "ES256",
+                                    "ES384",
+                                    "PS256",
+                                    "RS256",
+                                    "RS384",
+                                    "RS512"
+                                  ],
+                                  "type": "string"
+                                },
+                                "assertionAudience": {
+                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "certificateHeader": {
+                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                  "enum": [
+                                    "x5c",
+                                    "x5t#S256"
+                                  ],
+                                  "type": "string"
+                                },
+                                "certificateRef": {
+                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                },
+                                "kid": {
+                                  "description": "Optional JWS key ID header.",
+                                  "type": "string"
+                                },
+                                "signingKeyRef": {
+                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assertionAudience",
+                                "signingKeyRef"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "certificateRef and certificateHeader must be set together",
+                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                }
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "clientId"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                            },
+                            {
+                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                            },
+                            {
+                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                            }
+                          ]
+                        },
+                        "path": {
+                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                          "pattern": "^/",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "clientAuth"
+                      ],
+                      "type": "object"
+                    },
+                    "resources": {
+                      "description": "Resources sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "description": "Scopes sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "subjectToken": {
+                      "description": "Subject token sent to the identity provider. Defaults to an OpenID Connect\nID token read from the Authorization Bearer header.",
+                      "properties": {
+                        "source": {
+                          "description": "Where to read the subject token. Defaults to the Authorization Bearer header.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "audience",
+                    "identityProvider",
+                    "resourceAuthorizationServer"
+                  ],
+                  "type": "object"
                 },
                 "gcp": {
                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -10153,18 +12126,24 @@
                       "type": "string"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                      "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                          "maxLength": 253,
+                          "minLength": 1,
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -10180,8 +12159,7 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "type": {
                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -10198,8 +12176,7 @@
                       "message": "audience is only valid with IdToken",
                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "key": {
                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -10207,7 +12184,7 @@
                   "type": "string"
                 },
                 "location": {
-                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.",
                   "properties": {
                     "cookie": {
                       "properties": {
@@ -10220,13 +12197,12 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "header": {
                       "properties": {
                         "name": {
-                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                           "maxLength": 256,
                           "minLength": 1,
                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -10241,8 +12217,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "queryParameter": {
                       "properties": {
@@ -10255,8 +12230,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -10265,26 +12239,599 @@
                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                     }
+                  ]
+                },
+                "oauthTokenExchange": {
+                  "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
+                  "properties": {
+                    "actorToken": {
+                      "description": "RFC 8693 delegation actor token. TokenExchange grant only.",
+                      "properties": {
+                        "mayAct": {
+                          "description": "may_act claim validation mode. When omitted, may_act is not enforced.",
+                          "enum": [
+                            "Required"
+                          ],
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Where to read the actor token. Actor tokens have no default source.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "mayAct Required requires tokenType Jwt",
+                          "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
+                        }
+                      ]
+                    },
+                    "additionalParams": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Extra form params; values are CEL expressions over the incoming request.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "audiences": {
+                      "description": "Audiences sent to the token endpoint.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "backendRef": {
+                      "description": "RFC 8693 token endpoint backend.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ]
+                    },
+                    "cache": {
+                      "description": "Response cache configuration.",
+                      "properties": {
+                        "inMemory": {
+                          "properties": {
+                            "defaultTtl": {
+                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                              "type": "string"
+                            },
+                            "maxEntries": {
+                              "description": "Default 8192; 0 disables the cache.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "clientAuth": {
+                      "description": "Client authentication for the token endpoint. When unset, none is sent.",
+                      "properties": {
+                        "clientId": {
+                          "description": "Client ID sent to the token endpoint.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "method": {
+                          "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                          "enum": [
+                            "ClientSecretBasic",
+                            "ClientSecretPost",
+                            "PrivateKeyJwt"
+                          ],
+                          "type": "string"
+                        },
+                        "privateKeyJwt": {
+                          "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                          "properties": {
+                            "alg": {
+                              "description": "JWS signing algorithm. Defaults to RS256.",
+                              "enum": [
+                                "ES256",
+                                "ES384",
+                                "PS256",
+                                "RS256",
+                                "RS384",
+                                "RS512"
+                              ],
+                              "type": "string"
+                            },
+                            "assertionAudience": {
+                              "description": "Audience for the client assertion, typically the token endpoint URL.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "certificateHeader": {
+                              "description": "JWS certificate header. Required when certificateRef is set.",
+                              "enum": [
+                                "x5c",
+                                "x5t#S256"
+                              ],
+                              "type": "string"
+                            },
+                            "certificateRef": {
+                              "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            },
+                            "kid": {
+                              "description": "Optional JWS key ID header.",
+                              "type": "string"
+                            },
+                            "signingKeyRef": {
+                              "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "assertionAudience",
+                            "signingKeyRef"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "certificateRef and certificateHeader must be set together",
+                              "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                            }
+                          ]
+                        },
+                        "secretRef": {
+                          "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                          "properties": {
+                            "group": {
+                              "description": "API group of the referenced credential; empty selects the core API group",
+                              "type": "string"
+                            },
+                            "key": {
+                              "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the referenced credential",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "custom credential refs must set both group and kind",
+                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "clientId"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                          "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                        },
+                        {
+                          "message": "secretRef is not valid with method PrivateKeyJwt",
+                          "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                        },
+                        {
+                          "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                          "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                        }
+                      ]
+                    },
+                    "grantType": {
+                      "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
+                      "enum": [
+                        "JwtBearer",
+                        "TokenExchange"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "description": "Where the exchanged token is written to the backend request.\nDefaults to Authorization: Bearer.",
+                      "properties": {
+                        "cookie": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "header": {
+                          "properties": {
+                            "name": {
+                              "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                              "type": "string"
+                            },
+                            "prefix": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "queryParameter": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                          "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                        }
+                      ]
+                    },
+                    "path": {
+                      "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                      "pattern": "^/",
+                      "type": "string"
+                    },
+                    "requestedTokenType": {
+                      "description": "RFC 8693 requested_token_type. Unlike subject/actor token types, only the\nbuilt-in values may be requested; custom URIs are not supported here.",
+                      "enum": [
+                        "AccessToken",
+                        "Jwt",
+                        "IdToken",
+                        "IdJag"
+                      ],
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "Resources sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "description": "Scopes sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "subjectToken": {
+                      "description": "Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.\nThe token type may be a built-in value or a custom absolute URI for providers\nthat support custom token exchange profiles.",
+                      "properties": {
+                        "source": {
+                          "description": "Where to read the token. CEL `expression` variant is permitted.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "backendRef"
                   ],
-                  "additionalProperties": false
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "actorToken is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.actorToken) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.requestedTokenType) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType IdJag is only supported by crossAppAccess",
+                      "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
+                    }
+                  ]
                 },
                 "passthrough": {
-                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
                   "type": "object"
                 },
                 "secretRef": {
-                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                  "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                   "properties": {
                     "group": {
-                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "description": "API group of the referenced credential; empty selects the core API group",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                      "maxLength": 253,
+                      "minLength": 1,
                       "type": "string"
                     },
                     "kind": {
-                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                       "type": "string"
                     },
                     "name": {
-                      "description": "The name of the referenced credential.",
+                      "description": "Name of the referenced credential",
                       "maxLength": 253,
                       "minLength": 1,
                       "type": "string"
@@ -10300,22 +12847,24 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
-                  "message": "location may only be set for key or passthrough auth",
+                  "message": "must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess (credentials may be combined with a primary auth kind)",
+                  "rule": "has(self.credentials) || has(self.key) || has(self.secretRef) || has(self.passthrough) || has(self.aws) || has(self.azure) || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)"
+                },
+                {
+                  "message": "location may only be set for key, secretRef, or passthrough auth",
                   "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
                 },
                 {
-                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                  "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "extAuth": {
               "description": "External authentication configuration for requests\nsent to this backend.",
@@ -10325,14 +12874,14 @@
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -10345,14 +12894,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -10368,11 +12917,10 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "cache": {
-                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
                   "properties": {
                     "key": {
                       "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
@@ -10403,8 +12951,7 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "failureMode": {
                   "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -10442,8 +12989,7 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -10468,8 +13014,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -10505,6 +13050,12 @@
                       "maxItems": 64,
                       "type": "array"
                     },
+                    "body": {
+                      "description": "Body is a CEL expression that produces the HTTP authorization request body.\nStrings and bytes are used directly; other values are JSON-encoded.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
                     "path": {
                       "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
                       "maxLength": 16384,
@@ -10529,18 +13080,16 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
-                  "message": "cache requires grpc",
-                  "rule": "!has(self.cache) || has(self.grpc)"
+                  "message": "forwardBody cannot be used with http.body",
+                  "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "health": {
               "description": "Settings for passive and active health checking.",
@@ -10557,6 +13106,7 @@
                     "duration": {
                       "default": "3s",
                       "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -10570,7 +13120,7 @@
                       ]
                     },
                     "healthThreshold": {
-                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "description": "EWMA health score threshold, from 0 to 100. When set, a backend is evicted\nonly if its computed health drops below this value after an unhealthy\nresponse (e.g. 50 evicts when EWMA health falls below 50%). Unlike\nconsecutiveFailures, this sliding-window average lets a single success delay\neviction. If both are set, either condition evicts; if neither, a single\nunhealthy response evicts.",
                       "format": "int32",
                       "maximum": 100,
                       "minimum": 0,
@@ -10584,8 +13134,7 @@
                       "type": "integer"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "unhealthyCondition": {
                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -10594,14 +13143,14 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "http": {
-              "description": "Settings for managing HTTP requests to the backend.",
+              "description": "Settings for managing HTTP requests to the backend",
               "properties": {
                 "requestTimeout": {
                   "description": "Deadline for receiving a response from the backend.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -10615,7 +13164,7 @@
                   ]
                 },
                 "version": {
-                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                   "enum": [
                     "HTTP1",
                     "HTTP2"
@@ -10623,8 +13172,7 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "mcp": {
               "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
@@ -10633,7 +13181,7 @@
                   "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
                   "properties": {
                     "audiences": {
-                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                       "items": {
                         "type": "string"
                       },
@@ -10645,8 +13193,44 @@
                       "description": "Client ID to use for short-circuiting Dynamic Client Registration.\nIf set, the gateway will not proxy registration requests to the IDP and instead return this client ID.",
                       "type": "string"
                     },
+                    "clientSecretRef": {
+                      "description": "Reference to a Kubernetes Secret holding the OAuth client secret of the app\nregistration identified by `clientId` (for example Entra ID confidential clients,\nwhich require the secret at the token endpoint). The gateway injects it into the\ntoken requests it proxies to the provider. Defaults to the `clientSecret` key;\noverride via `clientSecretRef.key`.",
+                      "properties": {
+                        "group": {
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced credential",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ]
+                    },
                     "issuer": {
-                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                       "maxLength": 256,
                       "minLength": 1,
                       "type": "string"
@@ -10659,14 +13243,14 @@
                           "properties": {
                             "group": {
                               "default": "",
-                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                               "maxLength": 253,
                               "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                               "type": "string"
                             },
                             "kind": {
                               "default": "Service",
-                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                               "maxLength": 63,
                               "minLength": 1,
                               "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -10679,14 +13263,14 @@
                               "type": "string"
                             },
                             "namespace": {
-                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                               "maxLength": 63,
                               "minLength": 1,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "type": "string"
                             },
                             "port": {
-                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                               "format": "int32",
                               "maximum": 65535,
                               "minimum": 1,
@@ -10702,11 +13286,11 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "cacheDuration": {
                           "default": "5m",
+                          "maxLength": 32,
                           "type": "string",
                           "x-kubernetes-validations": [
                             {
@@ -10730,8 +13314,7 @@
                         "backendRef",
                         "jwksPath"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "mode": {
                       "default": "Strict",
@@ -10747,6 +13330,9 @@
                       "description": "Identity provider to use for authentication.",
                       "enum": [
                         "Auth0",
+                        "Authentik",
+                        "Descope",
+                        "Entra",
                         "Keycloak",
                         "Okta"
                       ],
@@ -10763,8 +13349,7 @@
                   "required": [
                     "jwks"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "authorization": {
                   "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
@@ -10780,7 +13365,7 @@
                       "type": "string"
                     },
                     "policy": {
-                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\n`Deny` is not recommended because expression failures fail to deny; prefer\n`Allow` or `Require`. If used, design expressions defensively against evaluation errors.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
                       "properties": {
                         "matchExpressions": {
                           "description": "CEL expressions that must all evaluate to true for the rule to match.",
@@ -10798,15 +13383,13 @@
                       "required": [
                         "matchExpressions"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
                     "policy"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "guardrails": {
                   "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
@@ -10865,14 +13448,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -10885,14 +13468,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -10908,8 +13491,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "disallowedRequestHeaders": {
                                 "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
@@ -10953,8 +13535,7 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
@@ -10966,8 +13547,7 @@
                             "message": "exactly one of the fields in [remote] must be set",
                             "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -10977,8 +13557,7 @@
                   "required": [
                     "processors"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -10987,14 +13566,14 @@
                   "message": "at least one of the fields in [authentication authorization guardrails] must be set",
                   "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tcp": {
-              "description": "Settings for managing TCP connections to the backend.",
+              "description": "Settings for managing TCP connections to the backend",
               "properties": {
                 "connectTimeout": {
                   "description": "Deadline for establishing a connection to\nthe destination.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -11012,6 +13591,7 @@
                   "properties": {
                     "interval": {
                       "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -11033,6 +13613,7 @@
                     },
                     "time": {
                       "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -11046,15 +13627,13 @@
                       ]
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "tls": {
-              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
               "properties": {
                 "alpnProtocols": {
                   "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -11074,20 +13653,19 @@
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "description": "Name of the referent",
                         "type": "string"
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "maxItems": 1,
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
                 },
                 "insecureSkipVerify": {
-                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                   "enum": [
                     "All",
                     "Hostname"
@@ -11108,20 +13686,20 @@
                   "type": "array"
                 },
                 "mtlsCertificateRef": {
-                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                   "items": {
-                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                    "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                     "properties": {
                       "group": {
-                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                        "description": "API group of the referenced credential; empty selects the core API group",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                         "type": "string"
                       },
                       "name": {
-                        "description": "The name of the referenced credential.",
+                        "description": "Name of the referenced credential",
                         "maxLength": 253,
                         "minLength": 1,
                         "type": "string"
@@ -11137,8 +13715,7 @@
                         "message": "custom credential refs must set both group and kind",
                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                       }
-                    ],
-                    "additionalProperties": false
+                    ]
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -11177,8 +13754,7 @@
                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -11214,8 +13790,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -11291,8 +13866,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -11309,8 +13883,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -11343,8 +13916,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -11420,8 +13992,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -11438,8 +14009,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "type": "object",
@@ -11448,25 +14018,24 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tunnel": {
-              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+              "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
               "properties": {
                 "backendRef": {
                   "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -11479,14 +14048,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -11502,15 +14071,13 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "required": [
                 "backendRef"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
           "type": "object",
@@ -11519,8 +14086,7 @@
               "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
               "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "static": {
           "description": "Static hostname, IP address, or Unix Domain Socket backend.",
@@ -11554,8 +14120,7 @@
               "message": "unixPath and host/port are mutually exclusive",
               "rule": "!has(self.unixPath) || (!has(self.host) && !has(self.port))"
             }
-          ],
-          "additionalProperties": false
+          ]
         }
       },
       "type": "object",
@@ -11572,8 +14137,7 @@
           "message": "exactly one of the fields in [ai static dynamicForwardProxy mcp aws a2a] must be set",
           "rule": "[has(self.ai),has(self.static),has(self.dynamicForwardProxy),has(self.mcp),has(self.aws),has(self.a2a)].filter(x,x==true).size() == 1"
         }
-      ],
-      "additionalProperties": false
+      ]
     },
     "status": {
       "description": "Current backend status.",
@@ -11629,8 +14193,7 @@
               "status",
               "type"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "maxItems": 8,
           "type": "array",
@@ -11640,8 +14203,7 @@
           "x-kubernetes-list-type": "map"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/agentgateway.dev/agentgatewaybackend_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaybackend_v1alpha1.json
@@ -35,7 +35,8 @@
             "host",
             "port"
           ],
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "ai": {
           "description": "LLM backend.",
@@ -58,7 +59,8 @@
                               "type": "string"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "azure": {
                           "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
@@ -106,7 +108,8 @@
                               "message": "projectName is required when resourceType is Foundry",
                               "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "azureopenai": {
                           "description": "Azure OpenAI provider settings.",
@@ -139,7 +142,8 @@
                               "message": "deploymentName is required for this apiVersion",
                               "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "bedrock": {
                           "description": "Bedrock provider settings.",
@@ -164,7 +168,8 @@
                                 "identifier",
                                 "version"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "model": {
                               "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
@@ -181,7 +186,8 @@
                               "type": "string"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "custom": {
                           "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
@@ -227,7 +233,8 @@
                                   "message": "Must have port for Service reference",
                                   "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "formats": {
                               "description": "Provider-native API formats this provider supports.",
@@ -263,7 +270,8 @@
                                     "message": "path must start with /",
                                     "rule": "!has(self.path) || self.path.startsWith('/')"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "maxItems": 6,
                               "minItems": 1,
@@ -289,7 +297,8 @@
                               "message": "custom provider backendRef may target only Service or InferencePool",
                               "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "gemini": {
                           "description": "Gemini provider settings.",
@@ -301,7 +310,8 @@
                               "type": "string"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "host": {
                           "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
@@ -326,7 +336,8 @@
                               "type": "string"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "path": {
                           "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
@@ -366,7 +377,8 @@
                                       "field",
                                       "value"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -400,7 +412,8 @@
                                       "field",
                                       "value"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -427,7 +440,8 @@
                                           "content",
                                           "role"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array"
                                     },
@@ -449,12 +463,14 @@
                                           "content",
                                           "role"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "promptCaching": {
                                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -482,12 +498,13 @@
                                     },
                                     "minTokens": {
                                       "default": 1024,
-                                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                                       "minimum": 0,
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "promptGuard": {
                                   "description": "Guardrails for LLM requests and responses.",
@@ -567,7 +584,8 @@
                                                                       "message": "exactly one of value or expression must be set",
                                                                       "rule": "has(self.value) != has(self.expression)"
                                                                     }
-                                                                  ]
+                                                                  ],
+                                                                  "additionalProperties": false
                                                                 },
                                                                 "maxItems": 50,
                                                                 "type": "array",
@@ -586,7 +604,8 @@
                                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "region": {
                                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -622,7 +641,8 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "serviceName": {
                                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -637,7 +657,8 @@
                                                             "message": "secretRef and assumeRole are mutually exclusive",
                                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       },
                                                       "key": {
                                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -658,7 +679,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "header": {
                                                             "properties": {
@@ -678,7 +700,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -691,7 +714,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           }
                                                         },
                                                         "type": "object",
@@ -700,7 +724,8 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       },
                                                       "secretRef": {
                                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -736,7 +761,8 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "type": "object",
@@ -749,7 +775,8 @@
                                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "http": {
                                                     "description": "Settings for managing HTTP requests to the backend",
@@ -778,7 +805,8 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tcp": {
                                                     "description": "Settings for managing TCP connections to the backend",
@@ -839,10 +867,12 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tls": {
                                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -870,7 +900,8 @@
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic"
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -927,7 +958,8 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ]
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -966,7 +998,8 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "tunnel": {
                                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -1019,13 +1052,15 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "type": "object",
@@ -1034,7 +1069,8 @@
                                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "region": {
                                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -1054,7 +1090,8 @@
                                               "region",
                                               "version"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "googleModelArmor": {
                                             "description": "Google Model Armor settings for prompt guarding.",
@@ -1115,7 +1152,8 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "type": {
                                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -1132,7 +1170,8 @@
                                                             "message": "audience is only valid with IdToken",
                                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "type": "object",
@@ -1141,7 +1180,8 @@
                                                         "message": "exactly one of the fields in [gcp] must be set",
                                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "http": {
                                                     "description": "Settings for managing HTTP requests to the backend",
@@ -1170,7 +1210,8 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tcp": {
                                                     "description": "Settings for managing TCP connections to the backend",
@@ -1231,10 +1272,12 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tls": {
                                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -1262,7 +1305,8 @@
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic"
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1319,7 +1363,8 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ]
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1358,7 +1403,8 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "tunnel": {
                                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -1411,13 +1457,15 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "type": "object",
@@ -1426,7 +1474,8 @@
                                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "projectId": {
                                                 "description": "Google Cloud project ID.",
@@ -1445,7 +1494,8 @@
                                               "projectId",
                                               "templateId"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "openAIModeration": {
                                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -1479,7 +1529,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "header": {
                                                             "properties": {
@@ -1499,7 +1550,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -1512,7 +1564,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           }
                                                         },
                                                         "type": "object",
@@ -1521,7 +1574,8 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       },
                                                       "secretRef": {
                                                         "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -1557,7 +1611,8 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "type": "object",
@@ -1566,7 +1621,8 @@
                                                         "message": "exactly one of the fields in [key secretRef] must be set",
                                                         "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "http": {
                                                     "description": "Settings for managing HTTP requests to the backend",
@@ -1595,7 +1651,8 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tcp": {
                                                     "description": "Settings for managing TCP connections to the backend",
@@ -1656,10 +1713,12 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tls": {
                                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -1687,7 +1746,8 @@
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic"
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1744,7 +1804,8 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ]
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -1783,7 +1844,8 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "tunnel": {
                                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -1836,13 +1898,15 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "type": "object",
@@ -1851,10 +1915,12 @@
                                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "regex": {
                                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -1893,7 +1959,8 @@
                                                 "type": "array"
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "response": {
                                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -1918,7 +1985,8 @@
                                                 "message": "at least one of the fields in [message statusCode] must be set",
                                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "webhook": {
                                             "description": "Webhook that receives requests for prompt guarding.",
@@ -1971,7 +2039,8 @@
                                                     "message": "Must have port for Service reference",
                                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "failureMode": {
                                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -2013,7 +2082,8 @@
                                                     "name",
                                                     "value"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "type": "array"
                                               },
@@ -2032,7 +2102,8 @@
                                             "required": [
                                               "backendRef"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -2041,7 +2112,8 @@
                                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 8,
                                       "minItems": 1,
@@ -2122,7 +2194,8 @@
                                                                       "message": "exactly one of value or expression must be set",
                                                                       "rule": "has(self.value) != has(self.expression)"
                                                                     }
-                                                                  ]
+                                                                  ],
+                                                                  "additionalProperties": false
                                                                 },
                                                                 "maxItems": 50,
                                                                 "type": "array",
@@ -2141,7 +2214,8 @@
                                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "region": {
                                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -2177,7 +2251,8 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "serviceName": {
                                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -2192,7 +2267,8 @@
                                                             "message": "secretRef and assumeRole are mutually exclusive",
                                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       },
                                                       "key": {
                                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -2213,7 +2289,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "header": {
                                                             "properties": {
@@ -2233,7 +2310,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "queryParameter": {
                                                             "properties": {
@@ -2246,7 +2324,8 @@
                                                             "required": [
                                                               "name"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           }
                                                         },
                                                         "type": "object",
@@ -2255,7 +2334,8 @@
                                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       },
                                                       "secretRef": {
                                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -2291,7 +2371,8 @@
                                                             "message": "custom credential refs must set both group and kind",
                                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "type": "object",
@@ -2304,7 +2385,8 @@
                                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "http": {
                                                     "description": "Settings for managing HTTP requests to the backend",
@@ -2333,7 +2415,8 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tcp": {
                                                     "description": "Settings for managing TCP connections to the backend",
@@ -2394,10 +2477,12 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tls": {
                                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -2425,7 +2510,8 @@
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic"
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -2482,7 +2568,8 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ]
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -2521,7 +2608,8 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "tunnel": {
                                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -2574,13 +2662,15 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "type": "object",
@@ -2589,7 +2679,8 @@
                                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "region": {
                                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -2609,7 +2700,8 @@
                                               "region",
                                               "version"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "googleModelArmor": {
                                             "description": "Google Model Armor settings for prompt guarding.",
@@ -2670,7 +2762,8 @@
                                                                 "message": "custom credential refs must set both group and kind",
                                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                               }
-                                                            ]
+                                                            ],
+                                                            "additionalProperties": false
                                                           },
                                                           "type": {
                                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -2687,7 +2780,8 @@
                                                             "message": "audience is only valid with IdToken",
                                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "type": "object",
@@ -2696,7 +2790,8 @@
                                                         "message": "exactly one of the fields in [gcp] must be set",
                                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "http": {
                                                     "description": "Settings for managing HTTP requests to the backend",
@@ -2725,7 +2820,8 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tcp": {
                                                     "description": "Settings for managing TCP connections to the backend",
@@ -2786,10 +2882,12 @@
                                                             ]
                                                           }
                                                         },
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       }
                                                     },
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "tls": {
                                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -2817,7 +2915,8 @@
                                                             }
                                                           },
                                                           "type": "object",
-                                                          "x-kubernetes-map-type": "atomic"
+                                                          "x-kubernetes-map-type": "atomic",
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -2874,7 +2973,8 @@
                                                               "message": "custom credential refs must set both group and kind",
                                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                             }
-                                                          ]
+                                                          ],
+                                                          "additionalProperties": false
                                                         },
                                                         "maxItems": 1,
                                                         "type": "array",
@@ -2913,7 +3013,8 @@
                                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                                       }
-                                                    ]
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
                                                   "tunnel": {
                                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -2966,13 +3067,15 @@
                                                             "message": "Must have port for Service reference",
                                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                           }
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false
                                                       }
                                                     },
                                                     "required": [
                                                       "backendRef"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "type": "object",
@@ -2981,7 +3084,8 @@
                                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "projectId": {
                                                 "description": "Google Cloud project ID.",
@@ -3000,7 +3104,8 @@
                                               "projectId",
                                               "templateId"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "regex": {
                                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -3039,7 +3144,8 @@
                                                 "type": "array"
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "response": {
                                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -3064,7 +3170,8 @@
                                                 "message": "at least one of the fields in [message statusCode] must be set",
                                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "webhook": {
                                             "description": "Webhook that receives responses for prompt guarding.",
@@ -3117,7 +3224,8 @@
                                                     "message": "Must have port for Service reference",
                                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "failureMode": {
                                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -3159,7 +3267,8 @@
                                                     "name",
                                                     "value"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "type": "array"
                                               },
@@ -3178,7 +3287,8 @@
                                             "required": [
                                               "backendRef"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -3187,7 +3297,8 @@
                                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 8,
                                       "minItems": 1,
@@ -3207,7 +3318,8 @@
                                       "message": "at least one of the fields in [request response] must be set",
                                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "routes": {
                                   "additionalProperties": {
@@ -3251,7 +3363,8 @@
                                       "expression",
                                       "field"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 64,
                                   "minItems": 1,
@@ -3264,7 +3377,8 @@
                                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "auth": {
                               "description": "Settings for managing authentication to the backend",
@@ -3324,7 +3438,8 @@
                                                 "message": "exactly one of value or expression must be set",
                                                 "rule": "has(self.value) != has(self.expression)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "maxItems": 50,
                                           "type": "array",
@@ -3343,7 +3458,8 @@
                                           "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                           "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "region": {
                                       "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -3379,7 +3495,8 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "serviceName": {
                                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -3394,7 +3511,8 @@
                                       "message": "secretRef and assumeRole are mutually exclusive",
                                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "azure": {
                                   "description": "Azure authentication method for the backend.",
@@ -3417,7 +3535,8 @@
                                         "objectId",
                                         "resourceId"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "secretRef": {
                                       "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
@@ -3447,7 +3566,8 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "workloadIdentity": {
                                       "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
@@ -3460,7 +3580,8 @@
                                       "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
                                       "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "credentials": {
                                   "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
@@ -3481,7 +3602,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -3501,7 +3623,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -3514,7 +3637,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -3523,7 +3647,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
@@ -3559,14 +3684,16 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "location",
                                       "secretRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 8,
                                   "minItems": 1,
@@ -3597,10 +3724,12 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "identityProvider": {
                                       "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
@@ -3653,7 +3782,8 @@
                                               "message": "Must have port for Service reference",
                                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "clientAuth": {
                                           "description": "Client authentication for the token endpoint.",
@@ -3734,7 +3864,8 @@
                                                       "message": "custom credential refs must set both group and kind",
                                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "kid": {
                                                   "description": "Optional JWS key ID header.",
@@ -3774,7 +3905,8 @@
                                                       "message": "custom credential refs must set both group and kind",
                                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 }
                                               },
                                               "required": [
@@ -3787,7 +3919,8 @@
                                                   "message": "certificateRef and certificateHeader must be set together",
                                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             },
                                             "secretRef": {
                                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -3823,7 +3956,8 @@
                                                   "message": "custom credential refs must set both group and kind",
                                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             }
                                           },
                                           "required": [
@@ -3843,7 +3977,8 @@
                                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "path": {
                                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -3855,7 +3990,8 @@
                                         "backendRef",
                                         "clientAuth"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "resourceAuthorizationServer": {
                                       "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
@@ -3908,7 +4044,8 @@
                                               "message": "Must have port for Service reference",
                                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "clientAuth": {
                                           "description": "Client authentication for the token endpoint.",
@@ -3989,7 +4126,8 @@
                                                       "message": "custom credential refs must set both group and kind",
                                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "kid": {
                                                   "description": "Optional JWS key ID header.",
@@ -4029,7 +4167,8 @@
                                                       "message": "custom credential refs must set both group and kind",
                                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 }
                                               },
                                               "required": [
@@ -4042,7 +4181,8 @@
                                                   "message": "certificateRef and certificateHeader must be set together",
                                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             },
                                             "secretRef": {
                                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -4078,7 +4218,8 @@
                                                   "message": "custom credential refs must set both group and kind",
                                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             }
                                           },
                                           "required": [
@@ -4098,7 +4239,8 @@
                                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "path": {
                                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -4110,7 +4252,8 @@
                                         "backendRef",
                                         "clientAuth"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "resources": {
                                       "description": "Resources sent to the token endpoint.",
@@ -4147,7 +4290,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "expression": {
                                               "description": "CEL expression that extracts the credential from the request.",
@@ -4173,7 +4317,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "queryParameter": {
                                               "properties": {
@@ -4186,7 +4331,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
                                           "type": "object",
@@ -4195,10 +4341,12 @@
                                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     }
                                   },
                                   "required": [
@@ -4206,7 +4354,8 @@
                                     "identityProvider",
                                     "resourceAuthorizationServer"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "gcp": {
                                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -4251,7 +4400,8 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "type": {
                                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -4268,7 +4418,8 @@
                                       "message": "audience is only valid with IdToken",
                                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "key": {
                                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -4289,7 +4440,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "header": {
                                       "properties": {
@@ -4309,7 +4461,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "queryParameter": {
                                       "properties": {
@@ -4322,7 +4475,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     }
                                   },
                                   "type": "object",
@@ -4331,7 +4485,8 @@
                                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "oauthTokenExchange": {
                                   "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
@@ -4360,7 +4515,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "expression": {
                                               "description": "CEL expression that extracts the credential from the request.",
@@ -4386,7 +4542,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "queryParameter": {
                                               "properties": {
@@ -4399,7 +4556,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
                                           "type": "object",
@@ -4408,7 +4566,8 @@
                                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "tokenType": {
                                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
@@ -4424,7 +4583,8 @@
                                           "message": "mayAct Required requires tokenType Jwt",
                                           "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "additionalParams": {
                                       "additionalProperties": {
@@ -4496,7 +4656,8 @@
                                           "message": "Must have port for Service reference",
                                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "cache": {
                                       "description": "Response cache configuration.",
@@ -4513,10 +4674,12 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "clientAuth": {
                                       "description": "Client authentication for the token endpoint. When unset, none is sent.",
@@ -4597,7 +4760,8 @@
                                                   "message": "custom credential refs must set both group and kind",
                                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             },
                                             "kid": {
                                               "description": "Optional JWS key ID header.",
@@ -4637,7 +4801,8 @@
                                                   "message": "custom credential refs must set both group and kind",
                                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                 }
-                                              ]
+                                              ],
+                                              "additionalProperties": false
                                             }
                                           },
                                           "required": [
@@ -4650,7 +4815,8 @@
                                               "message": "certificateRef and certificateHeader must be set together",
                                               "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "secretRef": {
                                           "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -4686,7 +4852,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         }
                                       },
                                       "required": [
@@ -4706,7 +4873,8 @@
                                           "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                           "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "grantType": {
                                       "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
@@ -4730,7 +4898,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "header": {
                                           "properties": {
@@ -4750,7 +4919,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "queryParameter": {
                                           "properties": {
@@ -4763,7 +4933,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         }
                                       },
                                       "type": "object",
@@ -4772,7 +4943,8 @@
                                           "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                           "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "path": {
                                       "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -4824,7 +4996,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "expression": {
                                               "description": "CEL expression that extracts the credential from the request.",
@@ -4850,7 +5023,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "queryParameter": {
                                               "properties": {
@@ -4863,7 +5037,8 @@
                                               "required": [
                                                 "name"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
                                           "type": "object",
@@ -4872,14 +5047,16 @@
                                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "tokenType": {
                                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     }
                                   },
                                   "required": [
@@ -4899,7 +5076,8 @@
                                       "message": "requestedTokenType IdJag is only supported by crossAppAccess",
                                       "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "passthrough": {
                                   "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
@@ -4939,7 +5117,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "type": "object",
@@ -4956,7 +5135,8 @@
                                   "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
                                   "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "health": {
                               "description": "Settings for passive and active health checking.",
@@ -5001,7 +5181,8 @@
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "unhealthyCondition": {
                                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -5010,7 +5191,8 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "http": {
                               "description": "Settings for managing HTTP requests to the backend",
@@ -5039,7 +5221,8 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "tcp": {
                               "description": "Settings for managing TCP connections to the backend",
@@ -5100,10 +5283,12 @@
                                       ]
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "tls": {
                               "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -5131,7 +5316,8 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic"
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 1,
                                   "type": "array",
@@ -5188,7 +5374,8 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "maxItems": 1,
                                   "type": "array",
@@ -5227,7 +5414,8 @@
                                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "transformation": {
                               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -5263,7 +5451,8 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -5339,7 +5528,8 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -5356,7 +5546,8 @@
                                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "response": {
                                   "description": "Response transformation settings.",
@@ -5389,7 +5580,8 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -5465,7 +5657,8 @@
                                           "name",
                                           "value"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -5482,7 +5675,8 @@
                                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "type": "object",
@@ -5491,7 +5685,8 @@
                                   "message": "at least one of the fields in [request response] must be set",
                                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "tunnel": {
                               "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -5544,13 +5739,15 @@
                                       "message": "Must have port for Service reference",
                                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
                                 "backendRef"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -5559,7 +5756,8 @@
                               "message": "at least one of the fields in [ai auth health http tcp tls transformation tunnel] must be set",
                               "rule": "[has(self.ai),has(self.auth),has(self.health),has(self.http),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "port": {
                           "description": "Port to send requests to.",
@@ -5594,7 +5792,8 @@
                           "required": [
                             "projectId"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "required": [
@@ -5626,7 +5825,8 @@
                           "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
                           "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "maxItems": 16,
                     "minItems": 1,
@@ -5642,7 +5842,8 @@
                 "required": [
                   "providers"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "maxItems": 8,
               "minItems": 1,
@@ -5661,7 +5862,8 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "azure": {
                   "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
@@ -5709,7 +5911,8 @@
                       "message": "projectName is required when resourceType is Foundry",
                       "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "azureopenai": {
                   "description": "Azure OpenAI provider settings.",
@@ -5742,7 +5945,8 @@
                       "message": "deploymentName is required for this apiVersion",
                       "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "bedrock": {
                   "description": "Bedrock provider settings.",
@@ -5767,7 +5971,8 @@
                         "identifier",
                         "version"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "model": {
                       "description": "Model name override, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
@@ -5784,7 +5989,8 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "custom": {
                   "description": "Custom provider configures a non-managed or self-hosted LLM provider.\nUse this when the provider target and API formats should be declared\nexplicitly instead of inferred from a managed provider such as OpenAI or\nAnthropic.",
@@ -5830,7 +6036,8 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "formats": {
                       "description": "Provider-native API formats this provider supports.",
@@ -5866,7 +6073,8 @@
                             "message": "path must start with /",
                             "rule": "!has(self.path) || self.path.startsWith('/')"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 6,
                       "minItems": 1,
@@ -5892,7 +6100,8 @@
                       "message": "custom provider backendRef may target only Service or InferencePool",
                       "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "gemini": {
                   "description": "Gemini provider settings.",
@@ -5904,7 +6113,8 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "host": {
                   "description": "Hostname to send requests to.\nFor custom providers without backendRef, host and port specify the target.\nFor managed providers, host and port override the provider default.",
@@ -5922,7 +6132,8 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "path": {
                   "description": "URL path to use for LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
@@ -5969,7 +6180,8 @@
                   "required": [
                     "projectId"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -5998,7 +6210,8 @@
                   "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock custom] must be set",
                   "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock),has(self.custom)].filter(x,x==true).size() == 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -6007,7 +6220,8 @@
               "message": "exactly one of the fields in [provider groups] must be set",
               "rule": "[has(self.provider),has(self.groups)].filter(x,x==true).size() == 1"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "aws": {
           "description": "AWS service backend, such as AgentCore.",
@@ -6027,7 +6241,8 @@
               "required": [
                 "agentRuntimeArn"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -6036,7 +6251,8 @@
               "message": "exactly one of the fields in [agentCore] must be set",
               "rule": "[has(self.agentCore)].filter(x,x==true).size() == 1"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "dynamicForwardProxy": {
           "description": "Dynamically sends requests to the destination based on the incoming\nrequest HTTP host header, or TLS SNI for TLS traffic.\n\nWarning: this backend type can send requests to arbitrary destinations. Proper\naccess controls must be put in place when using this backend type.",
@@ -6114,7 +6330,8 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -6128,7 +6345,8 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic"
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
                       },
                       "services": {
                         "description": "`services` is the label selector for which `Service` resources should be\nselected.",
@@ -6159,7 +6377,8 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -6173,7 +6392,8 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic"
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
                       }
                     },
                     "type": "object",
@@ -6182,7 +6402,8 @@
                         "message": "at least one of the fields in [namespaces services] must be set",
                         "rule": "[has(self.namespaces),has(self.services)].filter(x,x==true).size() >= 1"
                       }
-                    ]
+                    ],
+                    "additionalProperties": false
                   },
                   "static": {
                     "description": "Static MCP destination. When connecting to\nin-cluster `Service` resources, it is recommended to use `selector`\ninstead.",
@@ -6197,7 +6418,8 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic"
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
                       },
                       "host": {
                         "description": "Hostname or IP address of the MCP target.",
@@ -6272,7 +6494,8 @@
                                               "message": "exactly one of value or expression must be set",
                                               "rule": "has(self.value) != has(self.expression)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 50,
                                         "type": "array",
@@ -6291,7 +6514,8 @@
                                         "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                         "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "region": {
                                     "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -6327,7 +6551,8 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "serviceName": {
                                     "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -6342,7 +6567,8 @@
                                     "message": "secretRef and assumeRole are mutually exclusive",
                                     "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "azure": {
                                 "description": "Azure authentication method for the backend.",
@@ -6365,7 +6591,8 @@
                                       "objectId",
                                       "resourceId"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "secretRef": {
                                     "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
@@ -6395,7 +6622,8 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "workloadIdentity": {
                                     "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
@@ -6408,7 +6636,8 @@
                                     "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
                                     "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "credentials": {
                                 "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
@@ -6429,7 +6658,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "header": {
                                           "properties": {
@@ -6449,7 +6679,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "queryParameter": {
                                           "properties": {
@@ -6462,7 +6693,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         }
                                       },
                                       "type": "object",
@@ -6471,7 +6703,8 @@
                                           "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                           "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     },
                                     "secretRef": {
                                       "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
@@ -6507,14 +6740,16 @@
                                           "message": "custom credential refs must set both group and kind",
                                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                         }
-                                      ]
+                                      ],
+                                      "additionalProperties": false
                                     }
                                   },
                                   "required": [
                                     "location",
                                     "secretRef"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 8,
                                 "minItems": 1,
@@ -6545,10 +6780,12 @@
                                             "type": "integer"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "identityProvider": {
                                     "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
@@ -6601,7 +6838,8 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "clientAuth": {
                                         "description": "Client authentication for the token endpoint.",
@@ -6682,7 +6920,8 @@
                                                     "message": "custom credential refs must set both group and kind",
                                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "kid": {
                                                 "description": "Optional JWS key ID header.",
@@ -6722,7 +6961,8 @@
                                                     "message": "custom credential refs must set both group and kind",
                                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
@@ -6735,7 +6975,8 @@
                                                 "message": "certificateRef and certificateHeader must be set together",
                                                 "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "secretRef": {
                                             "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -6771,7 +7012,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           }
                                         },
                                         "required": [
@@ -6791,7 +7033,8 @@
                                             "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                             "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "path": {
                                         "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -6803,7 +7046,8 @@
                                       "backendRef",
                                       "clientAuth"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "resourceAuthorizationServer": {
                                     "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
@@ -6856,7 +7100,8 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "clientAuth": {
                                         "description": "Client authentication for the token endpoint.",
@@ -6937,7 +7182,8 @@
                                                     "message": "custom credential refs must set both group and kind",
                                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               },
                                               "kid": {
                                                 "description": "Optional JWS key ID header.",
@@ -6977,7 +7223,8 @@
                                                     "message": "custom credential refs must set both group and kind",
                                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                                   }
-                                                ]
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
@@ -6990,7 +7237,8 @@
                                                 "message": "certificateRef and certificateHeader must be set together",
                                                 "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "secretRef": {
                                             "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -7026,7 +7274,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           }
                                         },
                                         "required": [
@@ -7046,7 +7295,8 @@
                                             "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                             "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "path": {
                                         "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -7058,7 +7308,8 @@
                                       "backendRef",
                                       "clientAuth"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "resources": {
                                     "description": "Resources sent to the token endpoint.",
@@ -7095,7 +7346,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "expression": {
                                             "description": "CEL expression that extracts the credential from the request.",
@@ -7121,7 +7373,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -7134,7 +7387,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -7143,10 +7397,12 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "required": [
@@ -7154,7 +7410,8 @@
                                   "identityProvider",
                                   "resourceAuthorizationServer"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "gcp": {
                                 "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -7199,7 +7456,8 @@
                                         "message": "custom credential refs must set both group and kind",
                                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "type": {
                                     "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -7216,7 +7474,8 @@
                                     "message": "audience is only valid with IdToken",
                                     "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "key": {
                                 "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -7237,7 +7496,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "header": {
                                     "properties": {
@@ -7257,7 +7517,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "queryParameter": {
                                     "properties": {
@@ -7270,7 +7531,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -7279,7 +7541,8 @@
                                     "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                     "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "oauthTokenExchange": {
                                 "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
@@ -7308,7 +7571,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "expression": {
                                             "description": "CEL expression that extracts the credential from the request.",
@@ -7334,7 +7598,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -7347,7 +7612,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -7356,7 +7622,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "tokenType": {
                                         "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
@@ -7372,7 +7639,8 @@
                                         "message": "mayAct Required requires tokenType Jwt",
                                         "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "additionalParams": {
                                     "additionalProperties": {
@@ -7444,7 +7712,8 @@
                                         "message": "Must have port for Service reference",
                                         "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "cache": {
                                     "description": "Response cache configuration.",
@@ -7461,10 +7730,12 @@
                                             "type": "integer"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "clientAuth": {
                                     "description": "Client authentication for the token endpoint. When unset, none is sent.",
@@ -7545,7 +7816,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "kid": {
                                             "description": "Optional JWS key ID header.",
@@ -7585,7 +7857,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           }
                                         },
                                         "required": [
@@ -7598,7 +7871,8 @@
                                             "message": "certificateRef and certificateHeader must be set together",
                                             "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -7634,7 +7908,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
@@ -7654,7 +7929,8 @@
                                         "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                                         "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "grantType": {
                                     "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
@@ -7678,7 +7954,8 @@
                                         "required": [
                                           "name"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "header": {
                                         "properties": {
@@ -7698,7 +7975,8 @@
                                         "required": [
                                           "name"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "queryParameter": {
                                         "properties": {
@@ -7711,7 +7989,8 @@
                                         "required": [
                                           "name"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -7720,7 +7999,8 @@
                                         "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                         "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "path": {
                                     "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -7772,7 +8052,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "expression": {
                                             "description": "CEL expression that extracts the credential from the request.",
@@ -7798,7 +8079,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -7811,7 +8093,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -7820,14 +8103,16 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "tokenType": {
                                         "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "required": [
@@ -7847,7 +8132,8 @@
                                     "message": "requestedTokenType IdJag is only supported by crossAppAccess",
                                     "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "passthrough": {
                                 "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
@@ -7887,7 +8173,8 @@
                                     "message": "custom credential refs must set both group and kind",
                                     "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               }
                             },
                             "type": "object",
@@ -7904,7 +8191,8 @@
                                 "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
                                 "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "http": {
                             "description": "Settings for managing HTTP requests to the backend",
@@ -7933,7 +8221,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "tcp": {
                             "description": "Settings for managing TCP connections to the backend",
@@ -7994,10 +8283,12 @@
                                     ]
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "tls": {
                             "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -8025,7 +8316,8 @@
                                     }
                                   },
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 1,
                                 "type": "array",
@@ -8082,7 +8374,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 1,
                                 "type": "array",
@@ -8121,7 +8414,8 @@
                                 "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                 "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "tunnel": {
                             "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -8174,16 +8468,19 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "port": {
                         "description": "Port number of the MCP target.",
@@ -8214,7 +8511,8 @@
                         "message": "exactly one of the fields in [host backendRef] must be set",
                         "rule": "[has(self.host),has(self.backendRef)].filter(x,x==true).size() == 1"
                       }
-                    ]
+                    ],
+                    "additionalProperties": false
                   }
                 },
                 "required": [
@@ -8226,7 +8524,8 @@
                     "message": "exactly one of the fields in [selector static] must be set",
                     "rule": "[has(self.selector),has(self.static)].filter(x,x==true).size() == 1"
                   }
-                ]
+                ],
+                "additionalProperties": false
               },
               "maxItems": 32,
               "minItems": 1,
@@ -8246,7 +8545,8 @@
           "required": [
             "targets"
           ],
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "policies": {
           "description": "Policies for communicating with this backend. Policies may also be set\nwith AgentgatewayPolicy. Backend policies take precedence over policy\nresources when they set the same field.",
@@ -8274,7 +8574,8 @@
                       "field",
                       "value"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -8308,7 +8609,8 @@
                       "field",
                       "value"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -8335,7 +8637,8 @@
                           "content",
                           "role"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -8357,12 +8660,14 @@
                           "content",
                           "role"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "promptCaching": {
                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -8390,12 +8695,13 @@
                     },
                     "minTokens": {
                       "default": 1024,
-                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                       "minimum": 0,
                       "type": "integer"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "promptGuard": {
                   "description": "Guardrails for LLM requests and responses.",
@@ -8475,7 +8781,8 @@
                                                       "message": "exactly one of value or expression must be set",
                                                       "rule": "has(self.value) != has(self.expression)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "maxItems": 50,
                                                 "type": "array",
@@ -8494,7 +8801,8 @@
                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "region": {
                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -8530,7 +8838,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -8545,7 +8854,8 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "key": {
                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -8566,7 +8876,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -8586,7 +8897,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -8599,7 +8911,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -8608,7 +8921,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -8644,7 +8958,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -8657,7 +8972,8 @@
                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -8686,7 +9002,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -8747,10 +9064,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -8778,7 +9097,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -8835,7 +9155,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -8874,7 +9195,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -8927,13 +9249,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -8942,7 +9266,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -8962,7 +9287,8 @@
                               "region",
                               "version"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -9023,7 +9349,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -9040,7 +9367,8 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -9049,7 +9377,8 @@
                                         "message": "exactly one of the fields in [gcp] must be set",
                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -9078,7 +9407,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -9139,10 +9469,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -9170,7 +9502,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9227,7 +9560,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9266,7 +9600,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -9319,13 +9654,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -9334,7 +9671,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -9353,7 +9691,8 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "openAIModeration": {
                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -9387,7 +9726,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -9407,7 +9747,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -9420,7 +9761,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -9429,7 +9771,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -9465,7 +9808,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -9474,7 +9818,8 @@
                                         "message": "exactly one of the fields in [key secretRef] must be set",
                                         "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -9503,7 +9848,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -9564,10 +9910,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -9595,7 +9943,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9652,7 +10001,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -9691,7 +10041,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -9744,13 +10095,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -9759,10 +10112,12 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -9801,7 +10156,8 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -9826,7 +10182,8 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "webhook": {
                             "description": "Webhook that receives requests for prompt guarding.",
@@ -9879,7 +10236,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -9921,7 +10279,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               },
@@ -9940,7 +10299,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -9949,7 +10309,8 @@
                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -10030,7 +10391,8 @@
                                                       "message": "exactly one of value or expression must be set",
                                                       "rule": "has(self.value) != has(self.expression)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "maxItems": 50,
                                                 "type": "array",
@@ -10049,7 +10411,8 @@
                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "region": {
                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -10085,7 +10448,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -10100,7 +10464,8 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "key": {
                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -10121,7 +10486,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -10141,7 +10507,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -10154,7 +10521,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -10163,7 +10531,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -10199,7 +10568,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -10212,7 +10582,8 @@
                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -10241,7 +10612,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -10302,10 +10674,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -10333,7 +10707,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -10390,7 +10765,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -10429,7 +10805,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -10482,13 +10859,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -10497,7 +10876,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -10517,7 +10897,8 @@
                               "region",
                               "version"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -10578,7 +10959,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -10595,7 +10977,8 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -10604,7 +10987,8 @@
                                         "message": "exactly one of the fields in [gcp] must be set",
                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -10633,7 +11017,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -10694,10 +11079,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -10725,7 +11112,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -10782,7 +11170,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -10821,7 +11210,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -10874,13 +11264,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -10889,7 +11281,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -10908,7 +11301,8 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -10947,7 +11341,8 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -10972,7 +11367,8 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "webhook": {
                             "description": "Webhook that receives responses for prompt guarding.",
@@ -11025,7 +11421,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -11067,7 +11464,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               },
@@ -11086,7 +11484,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -11095,7 +11494,8 @@
                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -11115,7 +11515,8 @@
                       "message": "at least one of the fields in [request response] must be set",
                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "routes": {
                   "additionalProperties": {
@@ -11159,7 +11560,8 @@
                       "expression",
                       "field"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -11172,7 +11574,8 @@
                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "auth": {
               "description": "Settings for managing authentication to the backend",
@@ -11232,7 +11635,8 @@
                                 "message": "exactly one of value or expression must be set",
                                 "rule": "has(self.value) != has(self.expression)"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "maxItems": 50,
                           "type": "array",
@@ -11251,7 +11655,8 @@
                           "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                           "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "region": {
                       "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -11287,7 +11692,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "serviceName": {
                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -11302,7 +11708,8 @@
                       "message": "secretRef and assumeRole are mutually exclusive",
                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "azure": {
                   "description": "Azure authentication method for the backend.",
@@ -11325,7 +11732,8 @@
                         "objectId",
                         "resourceId"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "secretRef": {
                       "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
@@ -11355,7 +11763,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "workloadIdentity": {
                       "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
@@ -11368,7 +11777,8 @@
                       "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
                       "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "credentials": {
                   "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
@@ -11389,7 +11799,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "header": {
                             "properties": {
@@ -11409,7 +11820,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "queryParameter": {
                             "properties": {
@@ -11422,7 +11834,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -11431,7 +11844,8 @@
                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "secretRef": {
                         "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
@@ -11467,14 +11881,16 @@
                             "message": "custom credential refs must set both group and kind",
                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "location",
                       "secretRef"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 8,
                   "minItems": 1,
@@ -11505,10 +11921,12 @@
                               "type": "integer"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "identityProvider": {
                       "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
@@ -11561,7 +11979,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "clientAuth": {
                           "description": "Client authentication for the token endpoint.",
@@ -11642,7 +12061,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "kid": {
                                   "description": "Optional JWS key ID header.",
@@ -11682,7 +12102,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
@@ -11695,7 +12116,8 @@
                                   "message": "certificateRef and certificateHeader must be set together",
                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "secretRef": {
                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -11731,7 +12153,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -11751,7 +12174,8 @@
                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "path": {
                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -11763,7 +12187,8 @@
                         "backendRef",
                         "clientAuth"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "resourceAuthorizationServer": {
                       "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
@@ -11816,7 +12241,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "clientAuth": {
                           "description": "Client authentication for the token endpoint.",
@@ -11897,7 +12323,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "kid": {
                                   "description": "Optional JWS key ID header.",
@@ -11937,7 +12364,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
@@ -11950,7 +12378,8 @@
                                   "message": "certificateRef and certificateHeader must be set together",
                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "secretRef": {
                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -11986,7 +12415,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -12006,7 +12436,8 @@
                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "path": {
                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -12018,7 +12449,8 @@
                         "backendRef",
                         "clientAuth"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "resources": {
                       "description": "Resources sent to the token endpoint.",
@@ -12055,7 +12487,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -12081,7 +12514,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -12094,7 +12528,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -12103,10 +12538,12 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -12114,7 +12551,8 @@
                     "identityProvider",
                     "resourceAuthorizationServer"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "gcp": {
                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -12159,7 +12597,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "type": {
                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -12176,7 +12615,8 @@
                       "message": "audience is only valid with IdToken",
                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "key": {
                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -12197,7 +12637,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "header": {
                       "properties": {
@@ -12217,7 +12658,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "queryParameter": {
                       "properties": {
@@ -12230,7 +12672,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -12239,7 +12682,8 @@
                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "oauthTokenExchange": {
                   "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
@@ -12268,7 +12712,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -12294,7 +12739,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -12307,7 +12753,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -12316,7 +12763,8 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "tokenType": {
                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
@@ -12332,7 +12780,8 @@
                           "message": "mayAct Required requires tokenType Jwt",
                           "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "additionalParams": {
                       "additionalProperties": {
@@ -12404,7 +12853,8 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "cache": {
                       "description": "Response cache configuration.",
@@ -12421,10 +12871,12 @@
                               "type": "integer"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "clientAuth": {
                       "description": "Client authentication for the token endpoint. When unset, none is sent.",
@@ -12505,7 +12957,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "kid": {
                               "description": "Optional JWS key ID header.",
@@ -12545,7 +12998,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -12558,7 +13012,8 @@
                               "message": "certificateRef and certificateHeader must be set together",
                               "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "secretRef": {
                           "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -12594,7 +13049,8 @@
                               "message": "custom credential refs must set both group and kind",
                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         }
                       },
                       "required": [
@@ -12614,7 +13070,8 @@
                           "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                           "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "grantType": {
                       "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
@@ -12638,7 +13095,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "header": {
                           "properties": {
@@ -12658,7 +13116,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "queryParameter": {
                           "properties": {
@@ -12671,7 +13130,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "type": "object",
@@ -12680,7 +13140,8 @@
                           "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                           "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "path": {
                       "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -12732,7 +13193,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -12758,7 +13220,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -12771,7 +13234,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -12780,14 +13244,16 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "tokenType": {
                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -12807,7 +13273,8 @@
                       "message": "requestedTokenType IdJag is only supported by crossAppAccess",
                       "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "passthrough": {
                   "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
@@ -12847,7 +13314,8 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -12864,7 +13332,8 @@
                   "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
                   "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "extAuth": {
               "description": "External authentication configuration for requests\nsent to this backend.",
@@ -12917,7 +13386,8 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "cache": {
                   "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
@@ -12951,7 +13421,8 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "failureMode": {
                   "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -12989,7 +13460,8 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -13014,7 +13486,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -13080,7 +13553,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -13089,7 +13563,8 @@
                   "message": "forwardBody cannot be used with http.body",
                   "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "health": {
               "description": "Settings for passive and active health checking.",
@@ -13134,7 +13609,8 @@
                       "type": "integer"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "unhealthyCondition": {
                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -13143,7 +13619,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "http": {
               "description": "Settings for managing HTTP requests to the backend",
@@ -13172,7 +13649,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "mcp": {
               "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
@@ -13181,7 +13659,7 @@
                   "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
                   "properties": {
                     "audiences": {
-                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                       "items": {
                         "type": "string"
                       },
@@ -13227,10 +13705,11 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "issuer": {
-                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                       "maxLength": 256,
                       "minLength": 1,
                       "type": "string"
@@ -13286,7 +13765,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "cacheDuration": {
                           "default": "5m",
@@ -13314,7 +13794,8 @@
                         "backendRef",
                         "jwksPath"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mode": {
                       "default": "Strict",
@@ -13349,7 +13830,8 @@
                   "required": [
                     "jwks"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "authorization": {
                   "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
@@ -13383,13 +13865,15 @@
                       "required": [
                         "matchExpressions"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
                     "policy"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "guardrails": {
                   "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
@@ -13491,7 +13975,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "disallowedRequestHeaders": {
                                 "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
@@ -13535,7 +14020,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "required": [
@@ -13547,7 +14033,8 @@
                             "message": "exactly one of the fields in [remote] must be set",
                             "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -13557,7 +14044,8 @@
                   "required": [
                     "processors"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -13566,7 +14054,8 @@
                   "message": "at least one of the fields in [authentication authorization guardrails] must be set",
                   "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tcp": {
               "description": "Settings for managing TCP connections to the backend",
@@ -13627,10 +14116,12 @@
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "tls": {
               "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -13658,7 +14149,8 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -13715,7 +14207,8 @@
                         "message": "custom credential refs must set both group and kind",
                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                       }
-                    ]
+                    ],
+                    "additionalProperties": false
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -13754,7 +14247,8 @@
                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -13790,7 +14284,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -13866,7 +14361,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -13883,7 +14379,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -13916,7 +14413,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -13992,7 +14490,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -14009,7 +14508,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -14018,7 +14518,8 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tunnel": {
               "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -14071,13 +14572,15 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "required": [
                 "backendRef"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -14086,7 +14589,8 @@
               "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
               "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "static": {
           "description": "Static hostname, IP address, or Unix Domain Socket backend.",
@@ -14120,7 +14624,8 @@
               "message": "unixPath and host/port are mutually exclusive",
               "rule": "!has(self.unixPath) || (!has(self.host) && !has(self.port))"
             }
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -14137,7 +14642,8 @@
           "message": "exactly one of the fields in [ai static dynamicForwardProxy mcp aws a2a] must be set",
           "rule": "[has(self.ai),has(self.static),has(self.dynamicForwardProxy),has(self.mcp),has(self.aws),has(self.a2a)].filter(x,x==true).size() == 1"
         }
-      ]
+      ],
+      "additionalProperties": false
     },
     "status": {
       "description": "Current backend status.",
@@ -14193,7 +14699,8 @@
               "status",
               "type"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "maxItems": 8,
           "type": "array",
@@ -14203,7 +14710,8 @@
           "x-kubernetes-list-type": "map"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/agentgateway.dev/agentgatewaymodel_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaymodel_v1alpha1.json
@@ -1,0 +1,5162 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired model configuration.",
+      "properties": {
+        "azure": {
+          "description": "Provider-specific settings for Azure AI.",
+          "properties": {
+            "apiVersion": {
+              "description": "The version of the Azure OpenAI API to use.\nIf unset, defaults to `v1`.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "projectName": {
+              "description": "The Foundry project name, required when `resourceType` is `Foundry`.\nUsed to construct paths: /api/projects/{projectName}/openai/v1/...",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "resourceName": {
+              "description": "The Azure resource name used to construct the endpoint host.\nFor OpenAI: {resourceName}.openai.azure.com\nFor Foundry: {resourceName}.services.ai.azure.com\nNote: when the Azure portal \"Foundry legacy\" template was used, the\ngenerated resource name may end in \"-resource\" (e.g. \"myproject-resource\");\nthat suffix is part of the resource name as the user configured it, not\npart of the hostname suffix agentgateway should append.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "resourceType": {
+              "description": "The type of Azure endpoint. Determines the host suffix.",
+              "enum": [
+                "Foundry",
+                "OpenAI"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "resourceName",
+            "resourceType"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "projectName is required when resourceType is Foundry",
+              "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "baseURL": {
+          "description": "BaseURL overrides the provider address and base path prefix. It must use the\nhttp or https scheme. Backend policies may override the default TLS\nconfiguration. Query parameters, fragments, and user info are not supported.",
+          "format": "uri",
+          "maxLength": 1024,
+          "minLength": 1,
+          "type": "string"
+        },
+        "bedrock": {
+          "description": "Provider-specific settings for Amazon Bedrock.",
+          "properties": {
+            "guardrail": {
+              "description": "Guardrail policy to use for the backend. See\n<https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.\nIf not specified, the AWS Guardrail policy will not be used.",
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the Guardrail policy to use for the backend.",
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version of the Guardrail policy to use for the backend.",
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "identifier",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "region": {
+              "default": "us-east-1",
+              "description": "AWS region to use for the backend.\nDefaults to `us-east-1` if not specified.",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-z0-9-]+$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "custom": {
+          "description": "Provider-specific settings for a custom provider.",
+          "properties": {
+            "backendRef": {
+              "description": "Kubernetes backend that serves this provider.\n`backendRef` may target only a namespace-local Service or InferencePool.\nIf unset, host and port must be set on the parent provider.",
+              "properties": {
+                "group": {
+                  "default": "",
+                  "description": "API group of the referenced resource. For example, `gateway.networking.k8s.io`.\nWhen unspecified or empty string, core API group is inferred.",
+                  "maxLength": 253,
+                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "default": "Service",
+                  "description": "Kind of the referenced resource. For example, `Service`.\nDefaults to \"Service\" when not specified.",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referenced resource.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Destination port number to use for this resource.\nRequired when the referenced resource is a Kubernetes Service.",
+                  "format": "int32",
+                  "maximum": 65535,
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Must have port for Service reference",
+                  "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "formats": {
+              "description": "Provider-native API formats this provider supports.",
+              "items": {
+                "description": "Provider-native LLM API format settings.",
+                "properties": {
+                  "path": {
+                    "description": "Default upstream path override for this format.\nIf unset, agentgateway uses the default path for the format.",
+                    "maxLength": 1024,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Provider-native API format.",
+                    "enum": [
+                      "AnthropicTokenCount",
+                      "Completions",
+                      "Embeddings",
+                      "Messages",
+                      "Realtime",
+                      "Rerank",
+                      "Responses"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "path must start with /",
+                    "rule": "!has(self.path) || self.path.startsWith('/')"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "maxItems": 6,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "type"
+              ],
+              "x-kubernetes-list-type": "map"
+            }
+          },
+          "required": [
+            "formats"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "custom provider backendRef may target only Service or InferencePool",
+              "rule": "!has(self.backendRef) || (((!has(self.backendRef.group) || self.backendRef.group == \"\") && (!has(self.backendRef.kind) || self.backendRef.kind == 'Service')) || (has(self.backendRef.group) && self.backendRef.group == 'inference.networking.k8s.io' && has(self.backendRef.kind) && self.backendRef.kind == 'InferencePool'))"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "Conditions for selecting this model from client requests.",
+          "properties": {
+            "model": {
+              "description": "Model name matched against client requests. It may be exact, a suffix\nwildcard such as `gpt-*`, a prefix wildcard such as `*-latest`, or `*`.\nWhen omitted, the model matches metadata.name exactly.",
+              "maxLength": 1024,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "model wildcards must be '*', a suffix like 'gpt-*', or a prefix like '*-latest'",
+                  "rule": "!self.contains('*') || (self.indexOf('*') == self.lastIndexOf('*') && (self.indexOf('*') == 0 || self.indexOf('*') == size(self) - 1))"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "parentRefs": {
+          "description": "Gateways and listeners to which this model attaches.",
+          "items": {
+            "description": "ParentReference identifies an API object (usually a Gateway) that can be considered\na parent of this resource (usually a route). There are two kinds of parent resources\nwith \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nThis API may be extended in the future to support additional kinds of parent\nresources.\n\nThe API object must be valid in the cluster; the Group and Kind must\nbe registered in the cluster for this reference to be valid.",
+            "properties": {
+              "group": {
+                "default": "gateway.networking.k8s.io",
+                "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              },
+              "kind": {
+                "default": "Gateway",
+                "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the referent.\n\nSupport: Core",
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent. Defaults to the Route's local namespace. Cross-namespace references must be explicitly allowed, for example via ReferenceGrant. Support: Core",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              },
+              "port": {
+                "description": "Port this Route targets on the parent, interpreted per parent kind (for example a Gateway listener port or Service port). Support: Extended",
+                "format": "int32",
+                "maximum": 65535,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "sectionName": {
+                "description": "Name of a section within the target resource, for example a Gateway Listener name or Service port name. Empty references the entire resource. Support: Core",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array"
+        },
+        "policies": {
+          "description": "Policies applied to this concrete model.",
+          "properties": {
+            "auth": {
+              "description": "Credentials used to authenticate requests to this model provider.",
+              "properties": {
+                "aws": {
+                  "description": "Explicit AWS authentication method for the model provider. When omitted,\ndefault AWS SDK credential discovery is used.",
+                  "properties": {
+                    "assumeRole": {
+                      "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                      "properties": {
+                        "roleArn": {
+                          "description": "AWS IAM role ARN to assume.",
+                          "minLength": 1,
+                          "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                          "pattern": "^[\\w+=,.@-]{2,64}$",
+                          "type": "string"
+                        },
+                        "sessionNameExpression": {
+                          "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                          "maxLength": 16384,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                          "items": {
+                            "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                            "properties": {
+                              "expression": {
+                                "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the tag key.",
+                                "maxLength": 128,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is a static tag value.",
+                                "maxLength": 256,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "exactly one of value or expression must be set",
+                                "rule": "has(self.value) != has(self.expression)"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "maxItems": 50,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "key"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        }
+                      },
+                      "required": [
+                        "roleArn"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                          "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "region": {
+                      "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
+                      "properties": {
+                        "group": {
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced credential",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "serviceName": {
+                      "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "secretRef and assumeRole are mutually exclusive",
+                      "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "description": "Azure authentication method for the model provider.",
+                  "properties": {
+                    "managedIdentity": {
+                      "description": "Managed identity authentication settings.",
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "objectId": {
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "objectId",
+                        "resourceId"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
+                      "properties": {
+                        "group": {
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced credential",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "workloadIdentity": {
+                      "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
+                      "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "credentials": {
+                  "description": "Credentials is a list of additional credentials to inject on the backend\nrequest. Each entry resolves a Secret key and writes its value to the\nentry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
+                  "items": {
+                    "description": "BackendAuthCredential specifies one additional credential to inject on the\nbackend request.",
+                    "properties": {
+                      "location": {
+                        "description": "Where the credential is inserted on the backend request.",
+                        "properties": {
+                          "cookie": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "header": {
+                            "properties": {
+                              "name": {
+                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "prefix": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "queryParameter": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
+                        "properties": {
+                          "group": {
+                            "description": "API group of the referenced credential; empty selects the core API group",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referenced credential",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "custom credential refs must set both group and kind",
+                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "location",
+                      "secretRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "gcp": {
+                  "description": "Google authentication method for the model provider. When omitted,\ndefault Google credential discovery is used.",
+                  "properties": {
+                    "audience": {
+                      "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
+                      "properties": {
+                        "group": {
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced credential",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                      "enum": [
+                        "AccessToken",
+                        "IdToken"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "audience is only valid with IdToken",
+                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "key": {
+                  "description": "Inline key to use as the value of the `Authorization` header. This option\nis the least secure; usage of a `Secret` is preferred.",
+                  "maxLength": 2048,
+                  "type": "string"
+                },
+                "location": {
+                  "description": "Where backend credentials are inserted. If omitted, credentials are\nwritten to the `Authorization` header with the `Bearer ` prefix. This\napplies to `key`, `secretRef`, and `passthrough`. Entries in\n`credentials` carry their own location.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "oauthTokenExchange": {
+                  "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523)\nauthentication.",
+                  "properties": {
+                    "actorToken": {
+                      "description": "RFC 8693 delegation actor token. TokenExchange grant only.",
+                      "properties": {
+                        "mayAct": {
+                          "description": "may_act claim validation mode. When omitted, may_act is not enforced.",
+                          "enum": [
+                            "Required"
+                          ],
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Where to read the actor token. Actor tokens have no default source.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "mayAct Required requires tokenType Jwt",
+                          "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "additionalParams": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Extra form params; values are CEL expressions over the incoming request.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "audiences": {
+                      "description": "Audiences sent to the token endpoint.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "backendRef": {
+                      "description": "RFC 8693 token endpoint backend.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "cache": {
+                      "description": "Response cache configuration.",
+                      "properties": {
+                        "inMemory": {
+                          "properties": {
+                            "defaultTtl": {
+                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                              "type": "string"
+                            },
+                            "maxEntries": {
+                              "description": "Default 8192; 0 disables the cache.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "clientAuth": {
+                      "description": "Client authentication for the token endpoint. When unset, none is sent.",
+                      "properties": {
+                        "clientId": {
+                          "description": "Client ID sent to the token endpoint.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "method": {
+                          "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                          "enum": [
+                            "ClientSecretBasic",
+                            "ClientSecretPost",
+                            "PrivateKeyJwt"
+                          ],
+                          "type": "string"
+                        },
+                        "privateKeyJwt": {
+                          "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                          "properties": {
+                            "alg": {
+                              "description": "JWS signing algorithm. Defaults to RS256.",
+                              "enum": [
+                                "ES256",
+                                "ES384",
+                                "PS256",
+                                "RS256",
+                                "RS384",
+                                "RS512"
+                              ],
+                              "type": "string"
+                            },
+                            "assertionAudience": {
+                              "description": "Audience for the client assertion, typically the token endpoint URL.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "certificateHeader": {
+                              "description": "JWS certificate header. Required when certificateRef is set.",
+                              "enum": [
+                                "x5c",
+                                "x5t#S256"
+                              ],
+                              "type": "string"
+                            },
+                            "certificateRef": {
+                              "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ],
+                              "additionalProperties": false
+                            },
+                            "kid": {
+                              "description": "Optional JWS key ID header.",
+                              "type": "string"
+                            },
+                            "signingKeyRef": {
+                              "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "assertionAudience",
+                            "signingKeyRef"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "certificateRef and certificateHeader must be set together",
+                              "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                          "properties": {
+                            "group": {
+                              "description": "API group of the referenced credential; empty selects the core API group",
+                              "type": "string"
+                            },
+                            "key": {
+                              "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the referenced credential",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "custom credential refs must set both group and kind",
+                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                            }
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "clientId"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                          "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                        },
+                        {
+                          "message": "secretRef is not valid with method PrivateKeyJwt",
+                          "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                        },
+                        {
+                          "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                          "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "grantType": {
+                      "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
+                      "enum": [
+                        "JwtBearer",
+                        "TokenExchange"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "description": "Where the exchanged token is written to the backend request.\nDefaults to Authorization: Bearer.",
+                      "properties": {
+                        "cookie": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "header": {
+                          "properties": {
+                            "name": {
+                              "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                              "type": "string"
+                            },
+                            "prefix": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "queryParameter": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                          "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                        }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                      "pattern": "^/",
+                      "type": "string"
+                    },
+                    "requestedTokenType": {
+                      "description": "RFC 8693 requested_token_type. Unlike subject/actor token types, only the\nbuilt-in values may be requested; custom URIs are not supported here.",
+                      "enum": [
+                        "AccessToken",
+                        "Jwt",
+                        "IdToken",
+                        "IdJag"
+                      ],
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "Resources sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "description": "Scopes sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "subjectToken": {
+                      "description": "Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.\nThe token type may be a built-in value or a custom absolute URI for providers\nthat support custom token exchange profiles.",
+                      "properties": {
+                        "source": {
+                          "description": "Where to read the token. CEL `expression` variant is permitted.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ],
+                          "additionalProperties": false
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "backendRef"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "actorToken is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.actorToken) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.requestedTokenType) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType IdJag is only supported by crossAppAccess",
+                      "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
+                    }
+                  ],
+                  "additionalProperties": false
+                },
+                "passthrough": {
+                  "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
+                  "type": "object"
+                },
+                "secretRef": {
+                  "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
+                  "properties": {
+                    "group": {
+                      "description": "API group of the referenced credential; empty selects the core API group",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referenced credential",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "custom credential refs must set both group and kind",
+                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange (credentials may be combined with a primary auth kind)",
+                  "rule": "has(self.credentials) || has(self.key) || has(self.secretRef) || has(self.passthrough) || has(self.aws) || has(self.azure) || has(self.gcp) || has(self.oauthTokenExchange)"
+                },
+                {
+                  "message": "location may only be set for key, secretRef, or passthrough auth",
+                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                },
+                {
+                  "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange] may be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange)].filter(x,x==true).size() <= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "authorization": {
+              "description": "Authorization rules that clients must satisfy to use this model.",
+              "properties": {
+                "action": {
+                  "default": "Allow",
+                  "description": "The effect of this rule when it matches.\nIf unspecified, defaults to `Allow`.\n`Require` rules are cumulative: all require rules must match.",
+                  "enum": [
+                    "Allow",
+                    "Deny",
+                    "Require"
+                  ],
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\n`Deny` is not recommended because expression failures fail to deny; prefer\n`Allow` or `Require`. If used, design expressions defensively against evaluation errors.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "CEL expressions that must all evaluate to true for the rule to match.",
+                      "items": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 256,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "policy"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "headers": {
+              "description": "Request and response header changes applied to provider traffic.",
+              "properties": {
+                "request": {
+                  "description": "Header changes to apply before forwarding a request.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the HTTP header, case-insensitive",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value for the HTTP header",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the HTTP header, case-insensitive",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value for the HTTP header",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "Header changes to apply before returning a response.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the HTTP header, case-insensitive",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value for the HTTP header",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the HTTP header, case-insensitive",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value for the HTTP header",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "health": {
+              "description": "Health checking and eviction behavior for this model provider.",
+              "properties": {
+                "eviction": {
+                  "description": "Settings for evicting unhealthy backends.",
+                  "properties": {
+                    "consecutiveFailures": {
+                      "description": "Number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "duration": {
+                      "default": "3s",
+                      "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "maxLength": 32,
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "evictionDuration must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "healthThreshold": {
+                      "description": "EWMA health score threshold, from 0 to 100. When set, a backend is evicted\nonly if its computed health drops below this value after an unhealthy\nresponse (e.g. 50 evicts when EWMA health falls below 50%). Unlike\nconsecutiveFailures, this sliding-window average lets a single success delay\neviction. If both are set, either condition evicts; if neither, a single\nunhealthy response evicts.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "restoreHealth": {
+                      "description": "Health score from 0 to 100 assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "unhealthyCondition": {
+                  "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "promptGuard": {
+              "description": "Guardrails for requests and responses sent to this model provider.",
+              "properties": {
+                "request": {
+                  "description": "Prompt guards to apply to requests sent by the client.",
+                  "items": {
+                    "description": "Prompt guards to apply to requests sent by the client.",
+                    "properties": {
+                      "bedrockGuardrails": {
+                        "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                        "properties": {
+                          "identifier": {
+                            "description": "Identifier of the Guardrail policy to use for the backend.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "policies": {
+                            "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                            "properties": {
+                              "auth": {
+                                "description": "Settings for authenticating to AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "aws": {
+                                    "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
+                                    "properties": {
+                                      "assumeRole": {
+                                        "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                        "properties": {
+                                          "roleArn": {
+                                            "description": "AWS IAM role ARN to assume.",
+                                            "minLength": 1,
+                                            "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                            "type": "string"
+                                          },
+                                          "sessionName": {
+                                            "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                            "pattern": "^[\\w+=,.@-]{2,64}$",
+                                            "type": "string"
+                                          },
+                                          "sessionNameExpression": {
+                                            "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "tags": {
+                                            "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                            "items": {
+                                              "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                              "properties": {
+                                                "expression": {
+                                                  "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                  "maxLength": 16384,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key is the tag key.",
+                                                  "maxLength": 128,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is a static tag value.",
+                                                  "maxLength": 256,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "exactly one of value or expression must be set",
+                                                  "rule": "has(self.value) != has(self.expression)"
+                                                }
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            "maxItems": 50,
+                                            "type": "array",
+                                            "x-kubernetes-list-map-keys": [
+                                              "key"
+                                            ],
+                                            "x-kubernetes-list-type": "map"
+                                          }
+                                        },
+                                        "required": [
+                                          "roleArn"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                            "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "region": {
+                                        "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "serviceName": {
+                                        "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "secretRef and assumeRole are mutually exclusive",
+                                        "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "key": {
+                                    "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
+                                    "maxLength": 2048,
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
+                                    "properties": {
+                                      "cookie": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "header": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "prefix": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "queryParameter": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                        "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "API group of the referenced credential; empty selects the core API group",
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referenced credential",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "location may only be set for key or secretRef auth",
+                                    "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
+                                  },
+                                  {
+                                    "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                    "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "description": "Settings for managing HTTP requests to the backend",
+                                "properties": {
+                                  "requestTimeout": {
+                                    "description": "Deadline for receiving a response from the backend.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "requestTimeout must be at least 1ms",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "version": {
+                                    "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
+                                    "enum": [
+                                      "HTTP1",
+                                      "HTTP2"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcp": {
+                                "description": "Settings for managing TCP connections to the backend",
+                                "properties": {
+                                  "connectTimeout": {
+                                    "description": "Deadline for establishing a connection to\nthe destination.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "connectTimeout must be at least 100ms",
+                                        "rule": "duration(self) >= duration('100ms')"
+                                      }
+                                    ]
+                                  },
+                                  "keepalive": {
+                                    "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                    "properties": {
+                                      "interval": {
+                                        "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "interval must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                        "format": "int32",
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "time": {
+                                        "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "time must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tls": {
+                                "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
+                                "properties": {
+                                  "alpnProtocols": {
+                                    "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                    "items": {
+                                      "maxLength": 64,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "caCertificateRefs": {
+                                    "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                    "items": {
+                                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "insecureSkipVerify": {
+                                    "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                                    "enum": [
+                                      "All",
+                                      "Hostname"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "keyExchangeGroups": {
+                                    "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                    "items": {
+                                      "enum": [
+                                        "P-256",
+                                        "P-384",
+                                        "X25519",
+                                        "X25519_MLKEM768"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mtlsCertificateRef": {
+                                    "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                                    "items": {
+                                      "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "sni": {
+                                    "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "verifySubjectAltNames": {
+                                    "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                  },
+                                  {
+                                    "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                  },
+                                  {
+                                    "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                    "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "tunnel": {
+                                "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
+                                "properties": {
+                                  "backendRef": {
+                                    "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "region": {
+                            "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version of the Guardrail policy to use for the backend.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "identifier",
+                          "region",
+                          "version"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "googleModelArmor": {
+                        "description": "Google Model Armor settings for prompt guarding.",
+                        "properties": {
+                          "location": {
+                            "default": "us-central1",
+                            "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "policies": {
+                            "description": "Policies for communicating with Google Model Armor.",
+                            "properties": {
+                              "auth": {
+                                "description": "Settings for authenticating to Google Model Armor.",
+                                "properties": {
+                                  "gcp": {
+                                    "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
+                                    "properties": {
+                                      "audience": {
+                                        "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "type": {
+                                        "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                        "enum": [
+                                          "AccessToken",
+                                          "IdToken"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "audience is only valid with IdToken",
+                                        "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "exactly one of the fields in [gcp] must be set",
+                                    "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "description": "Settings for managing HTTP requests to the backend",
+                                "properties": {
+                                  "requestTimeout": {
+                                    "description": "Deadline for receiving a response from the backend.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "requestTimeout must be at least 1ms",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "version": {
+                                    "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
+                                    "enum": [
+                                      "HTTP1",
+                                      "HTTP2"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcp": {
+                                "description": "Settings for managing TCP connections to the backend",
+                                "properties": {
+                                  "connectTimeout": {
+                                    "description": "Deadline for establishing a connection to\nthe destination.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "connectTimeout must be at least 100ms",
+                                        "rule": "duration(self) >= duration('100ms')"
+                                      }
+                                    ]
+                                  },
+                                  "keepalive": {
+                                    "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                    "properties": {
+                                      "interval": {
+                                        "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "interval must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                        "format": "int32",
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "time": {
+                                        "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "time must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tls": {
+                                "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
+                                "properties": {
+                                  "alpnProtocols": {
+                                    "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                    "items": {
+                                      "maxLength": 64,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "caCertificateRefs": {
+                                    "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                    "items": {
+                                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "insecureSkipVerify": {
+                                    "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                                    "enum": [
+                                      "All",
+                                      "Hostname"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "keyExchangeGroups": {
+                                    "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                    "items": {
+                                      "enum": [
+                                        "P-256",
+                                        "P-384",
+                                        "X25519",
+                                        "X25519_MLKEM768"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mtlsCertificateRef": {
+                                    "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                                    "items": {
+                                      "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "sni": {
+                                    "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "verifySubjectAltNames": {
+                                    "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                  },
+                                  {
+                                    "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                  },
+                                  {
+                                    "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                    "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "tunnel": {
+                                "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
+                                "properties": {
+                                  "backendRef": {
+                                    "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "projectId": {
+                            "description": "Google Cloud project ID.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "templateId": {
+                            "description": "Template ID for Google Model Armor.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "projectId",
+                          "templateId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "openAIModeration": {
+                        "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                        "properties": {
+                          "model": {
+                            "description": "Moderation model to use. For example,\n`omni-moderation`.",
+                            "type": "string"
+                          },
+                          "policies": {
+                            "description": "Policies for communicating with OpenAI.",
+                            "properties": {
+                              "auth": {
+                                "description": "Settings for authenticating to OpenAI.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                    "maxLength": 2048,
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "description": "Where backend credentials are inserted. Defaults to the `Authorization`\nheader with the `Bearer ` prefix. Applies to `key` and `secretRef`.",
+                                    "properties": {
+                                      "cookie": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "header": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "prefix": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "queryParameter": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                        "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "API group of the referenced credential; empty selects the core API group",
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referenced credential",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "exactly one of the fields in [key secretRef] must be set",
+                                    "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "description": "Settings for managing HTTP requests to the backend",
+                                "properties": {
+                                  "requestTimeout": {
+                                    "description": "Deadline for receiving a response from the backend.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "requestTimeout must be at least 1ms",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "version": {
+                                    "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
+                                    "enum": [
+                                      "HTTP1",
+                                      "HTTP2"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcp": {
+                                "description": "Settings for managing TCP connections to the backend",
+                                "properties": {
+                                  "connectTimeout": {
+                                    "description": "Deadline for establishing a connection to\nthe destination.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "connectTimeout must be at least 100ms",
+                                        "rule": "duration(self) >= duration('100ms')"
+                                      }
+                                    ]
+                                  },
+                                  "keepalive": {
+                                    "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                    "properties": {
+                                      "interval": {
+                                        "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "interval must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                        "format": "int32",
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "time": {
+                                        "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "time must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tls": {
+                                "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
+                                "properties": {
+                                  "alpnProtocols": {
+                                    "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                    "items": {
+                                      "maxLength": 64,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "caCertificateRefs": {
+                                    "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                    "items": {
+                                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "insecureSkipVerify": {
+                                    "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                                    "enum": [
+                                      "All",
+                                      "Hostname"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "keyExchangeGroups": {
+                                    "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                    "items": {
+                                      "enum": [
+                                        "P-256",
+                                        "P-384",
+                                        "X25519",
+                                        "X25519_MLKEM768"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mtlsCertificateRef": {
+                                    "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                                    "items": {
+                                      "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "sni": {
+                                    "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "verifySubjectAltNames": {
+                                    "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                  },
+                                  {
+                                    "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                  },
+                                  {
+                                    "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                    "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "tunnel": {
+                                "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
+                                "properties": {
+                                  "backendRef": {
+                                    "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "regex": {
+                        "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                        "properties": {
+                          "action": {
+                            "default": "Mask",
+                            "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                            "enum": [
+                              "Mask",
+                              "Reject"
+                            ],
+                            "type": "string"
+                          },
+                          "builtins": {
+                            "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                            "items": {
+                              "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                              "enum": [
+                                "CaSin",
+                                "CreditCard",
+                                "Email",
+                                "PhoneNumber",
+                                "Ssn"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "matches": {
+                            "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                            "items": {
+                              "maxLength": 1024,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "response": {
+                        "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                        "properties": {
+                          "message": {
+                            "default": "The request was rejected due to inappropriate content",
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "type": "string"
+                          },
+                          "statusCode": {
+                            "default": 403,
+                            "description": "Status code to return to the client. Defaults to 403.",
+                            "format": "int32",
+                            "maximum": 599,
+                            "minimum": 200,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [message statusCode] must be set",
+                            "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "webhook": {
+                        "description": "Webhook that receives requests for prompt guarding.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "failureMode": {
+                            "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                            "enum": [
+                              "FailClosed",
+                              "FailOpen"
+                            ],
+                            "type": "string"
+                          },
+                          "forwardHeaderMatches": {
+                            "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                            "items": {
+                              "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "default": "Exact",
+                                  "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
+                                  "enum": [
+                                    "Exact",
+                                    "RegularExpression"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value of the HTTP header to match",
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "description": "A Common Expression Language (CEL) expression.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "description": "CEL-computed headers to include in webhook requests.",
+                            "maxProperties": 64,
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "backendRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                        "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "response": {
+                  "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                  "items": {
+                    "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                    "properties": {
+                      "bedrockGuardrails": {
+                        "description": "AWS Bedrock Guardrails settings for prompt\nguarding.",
+                        "properties": {
+                          "identifier": {
+                            "description": "Identifier of the Guardrail policy to use for the backend.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "policies": {
+                            "description": "Policies for communicating with AWS Bedrock Guardrails.",
+                            "properties": {
+                              "auth": {
+                                "description": "Settings for authenticating to AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "aws": {
+                                    "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
+                                    "properties": {
+                                      "assumeRole": {
+                                        "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
+                                        "properties": {
+                                          "roleArn": {
+                                            "description": "AWS IAM role ARN to assume.",
+                                            "minLength": 1,
+                                            "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
+                                            "type": "string"
+                                          },
+                                          "sessionName": {
+                                            "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                            "pattern": "^[\\w+=,.@-]{2,64}$",
+                                            "type": "string"
+                                          },
+                                          "sessionNameExpression": {
+                                            "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "tags": {
+                                            "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                            "items": {
+                                              "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                              "properties": {
+                                                "expression": {
+                                                  "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                  "maxLength": 16384,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "key": {
+                                                  "description": "Key is the tag key.",
+                                                  "maxLength": 128,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is a static tag value.",
+                                                  "maxLength": 256,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-validations": [
+                                                {
+                                                  "message": "exactly one of value or expression must be set",
+                                                  "rule": "has(self.value) != has(self.expression)"
+                                                }
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            "maxItems": 50,
+                                            "type": "array",
+                                            "x-kubernetes-list-map-keys": [
+                                              "key"
+                                            ],
+                                            "x-kubernetes-list-type": "map"
+                                          }
+                                        },
+                                        "required": [
+                                          "roleArn"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                            "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "region": {
+                                        "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "serviceName": {
+                                        "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "secretRef and assumeRole are mutually exclusive",
+                                        "rule": "!(has(self.secretRef) && has(self.assumeRole))"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "key": {
+                                    "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
+                                    "maxLength": 2048,
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
+                                    "properties": {
+                                      "cookie": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "header": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string"
+                                          },
+                                          "prefix": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "queryParameter": {
+                                        "properties": {
+                                          "name": {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                        "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
+                                    "properties": {
+                                      "group": {
+                                        "description": "API group of the referenced credential; empty selects the core API group",
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referenced credential",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "custom credential refs must set both group and kind",
+                                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "location may only be set for key or secretRef auth",
+                                    "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
+                                  },
+                                  {
+                                    "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                    "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "description": "Settings for managing HTTP requests to the backend",
+                                "properties": {
+                                  "requestTimeout": {
+                                    "description": "Deadline for receiving a response from the backend.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "requestTimeout must be at least 1ms",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "version": {
+                                    "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
+                                    "enum": [
+                                      "HTTP1",
+                                      "HTTP2"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcp": {
+                                "description": "Settings for managing TCP connections to the backend",
+                                "properties": {
+                                  "connectTimeout": {
+                                    "description": "Deadline for establishing a connection to\nthe destination.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "connectTimeout must be at least 100ms",
+                                        "rule": "duration(self) >= duration('100ms')"
+                                      }
+                                    ]
+                                  },
+                                  "keepalive": {
+                                    "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                    "properties": {
+                                      "interval": {
+                                        "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "interval must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                        "format": "int32",
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "time": {
+                                        "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "time must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tls": {
+                                "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
+                                "properties": {
+                                  "alpnProtocols": {
+                                    "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                    "items": {
+                                      "maxLength": 64,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "caCertificateRefs": {
+                                    "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                    "items": {
+                                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "insecureSkipVerify": {
+                                    "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                                    "enum": [
+                                      "All",
+                                      "Hostname"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "keyExchangeGroups": {
+                                    "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                    "items": {
+                                      "enum": [
+                                        "P-256",
+                                        "P-384",
+                                        "X25519",
+                                        "X25519_MLKEM768"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mtlsCertificateRef": {
+                                    "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                                    "items": {
+                                      "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "sni": {
+                                    "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "verifySubjectAltNames": {
+                                    "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                  },
+                                  {
+                                    "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                  },
+                                  {
+                                    "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                    "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "tunnel": {
+                                "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
+                                "properties": {
+                                  "backendRef": {
+                                    "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "region": {
+                            "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version of the Guardrail policy to use for the backend.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "identifier",
+                          "region",
+                          "version"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "googleModelArmor": {
+                        "description": "Google Model Armor settings for prompt guarding.",
+                        "properties": {
+                          "location": {
+                            "default": "us-central1",
+                            "description": "Google Cloud location, for example `us-central1`.\nDefaults to `us-central1` if not specified.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "policies": {
+                            "description": "Policies for communicating with Google Model Armor.",
+                            "properties": {
+                              "auth": {
+                                "description": "Settings for authenticating to Google Model Armor.",
+                                "properties": {
+                                  "gcp": {
+                                    "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
+                                    "properties": {
+                                      "audience": {
+                                        "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
+                                        "properties": {
+                                          "group": {
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referenced credential",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "custom credential refs must set both group and kind",
+                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                          }
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "type": {
+                                        "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                        "enum": [
+                                          "AccessToken",
+                                          "IdToken"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "audience is only valid with IdToken",
+                                        "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "exactly one of the fields in [gcp] must be set",
+                                    "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "description": "Settings for managing HTTP requests to the backend",
+                                "properties": {
+                                  "requestTimeout": {
+                                    "description": "Deadline for receiving a response from the backend.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "requestTimeout must be at least 1ms",
+                                        "rule": "duration(self) >= duration('1ms')"
+                                      }
+                                    ]
+                                  },
+                                  "version": {
+                                    "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
+                                    "enum": [
+                                      "HTTP1",
+                                      "HTTP2"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcp": {
+                                "description": "Settings for managing TCP connections to the backend",
+                                "properties": {
+                                  "connectTimeout": {
+                                    "description": "Deadline for establishing a connection to\nthe destination.",
+                                    "maxLength": 32,
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "connectTimeout must be at least 100ms",
+                                        "rule": "duration(self) >= duration('100ms')"
+                                      }
+                                    ]
+                                  },
+                                  "keepalive": {
+                                    "description": "Settings for enabling TCP keepalives on the\nconnection.",
+                                    "properties": {
+                                      "interval": {
+                                        "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "interval must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "Maximum number of keepalive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                        "format": "int32",
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "time": {
+                                        "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                        "maxLength": 32,
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "time must be at least 1 second",
+                                            "rule": "duration(self) >= duration('1s')"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tls": {
+                                "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
+                                "properties": {
+                                  "alpnProtocols": {
+                                    "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                    "items": {
+                                      "maxLength": 64,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  },
+                                  "caCertificateRefs": {
+                                    "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                    "items": {
+                                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "insecureSkipVerify": {
+                                    "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                                    "enum": [
+                                      "All",
+                                      "Hostname"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "keyExchangeGroups": {
+                                    "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                    "items": {
+                                      "enum": [
+                                        "P-256",
+                                        "P-384",
+                                        "X25519",
+                                        "X25519_MLKEM768"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mtlsCertificateRef": {
+                                    "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                                    "items": {
+                                      "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                                      "properties": {
+                                        "group": {
+                                          "description": "API group of the referenced credential; empty selects the core API group",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referenced credential",
+                                          "maxLength": 253,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "custom credential refs must set both group and kind",
+                                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                        }
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "sni": {
+                                    "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "verifySubjectAltNames": {
+                                    "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                    "items": {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "maxItems": 16,
+                                    "minItems": 1,
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                  },
+                                  {
+                                    "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                    "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                  },
+                                  {
+                                    "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                    "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                  }
+                                ],
+                                "additionalProperties": false
+                              },
+                              "tunnel": {
+                                "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
+                                "properties": {
+                                  "backendRef": {
+                                    "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                    "properties": {
+                                      "group": {
+                                        "default": "",
+                                        "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                        "maxLength": 253,
+                                        "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "default": "Service",
+                                        "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of the referent.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                        "maxLength": 63,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "Must have port for Service reference",
+                                        "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                      }
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "backendRef"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "projectId": {
+                            "description": "Google Cloud project ID.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "templateId": {
+                            "description": "Template ID for Google Model Armor.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "projectId",
+                          "templateId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "regex": {
+                        "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                        "properties": {
+                          "action": {
+                            "default": "Mask",
+                            "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                            "enum": [
+                              "Mask",
+                              "Reject"
+                            ],
+                            "type": "string"
+                          },
+                          "builtins": {
+                            "description": "Built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                            "items": {
+                              "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                              "enum": [
+                                "CaSin",
+                                "CreditCard",
+                                "Email",
+                                "PhoneNumber",
+                                "Ssn"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "matches": {
+                            "description": "Regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                            "items": {
+                              "maxLength": 1024,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "response": {
+                        "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                        "properties": {
+                          "message": {
+                            "default": "The request was rejected due to inappropriate content",
+                            "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "type": "string"
+                          },
+                          "statusCode": {
+                            "default": 403,
+                            "description": "Status code to return to the client. Defaults to 403.",
+                            "format": "int32",
+                            "maximum": 599,
+                            "minimum": 200,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [message statusCode] must be set",
+                            "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                          }
+                        ],
+                        "additionalProperties": false
+                      },
+                      "webhook": {
+                        "description": "Webhook that receives responses for prompt guarding.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "Webhook server to reach.\n\nSupported types: Service and Backend.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ],
+                            "additionalProperties": false
+                          },
+                          "failureMode": {
+                            "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
+                            "enum": [
+                              "FailClosed",
+                              "FailOpen"
+                            ],
+                            "type": "string"
+                          },
+                          "forwardHeaderMatches": {
+                            "description": "HTTP header matches used to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                            "items": {
+                              "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "default": "Exact",
+                                  "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
+                                  "enum": [
+                                    "Exact",
+                                    "RegularExpression"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value of the HTTP header to match",
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "description": "A Common Expression Language (CEL) expression.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "description": "CEL-computed headers to include in webhook requests.",
+                            "maxProperties": 64,
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "backendRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                        "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "streaming": {
+                  "description": "Apply prompt guards to streaming responses and realtime websocket messages.\nDefaults to disabled to preserve streaming throughput unless explicitly enabled.",
+                  "enum": [
+                    "Enabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "TLS settings for connections to this model provider.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "caCertificateRefs": {
+                  "description": "CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "insecureSkipVerify": {
+                  "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
+                  "enum": [
+                    "All",
+                    "Hostname"
+                  ],
+                  "type": "string"
+                },
+                "keyExchangeGroups": {
+                  "description": "Ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "P-256",
+                      "P-384",
+                      "X25519",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mtlsCertificateRef": {
+                  "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
+                  "items": {
+                    "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
+                    "properties": {
+                      "group": {
+                        "description": "API group of the referenced credential; empty selects the core API group",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referenced credential",
+                        "maxLength": 253,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "custom credential refs must set both group and kind",
+                        "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                      }
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "sni": {
+                  "description": "Server Name Indicator (`SNI`) to use in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "verifySubjectAltNames": {
+                  "description": "Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                },
+                {
+                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                },
+                {
+                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                }
+              ],
+              "additionalProperties": false
+            },
+            "transformations": {
+              "description": "CEL transformations applied to fields in the provider request body.",
+              "items": {
+                "description": "Maps a request JSON field to a CEL expression.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                "properties": {
+                  "expression": {
+                    "description": "CEL expression used to compute the field value.",
+                    "maxLength": 16384,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "field": {
+                    "description": "Name of the field to set.",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expression",
+                  "field"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 64,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "field"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "tunnel": {
+              "description": "Proxy tunnel used to reach this model provider.",
+              "properties": {
+                "backendRef": {
+                  "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [auth authorization headers health promptGuard tls transformations tunnel] must be set",
+              "rule": "[has(self.auth),has(self.authorization),has(self.headers),has(self.health),has(self.promptGuard),has(self.tls),has(self.transformations),has(self.tunnel)].filter(x,x==true).size() >= 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Provider serving this concrete model. Provider-specific configuration is\nset by the corresponding field below when needed.",
+          "enum": [
+            "Anthropic",
+            "Azure",
+            "Baseten",
+            "Bedrock",
+            "Cerebras",
+            "Cohere",
+            "Custom",
+            "Deepinfra",
+            "Deepseek",
+            "Fireworks",
+            "Gemini",
+            "Groq",
+            "Huggingface",
+            "Mistral",
+            "Ollama",
+            "OpenAI",
+            "Openrouter",
+            "TogetherAI",
+            "VertexAI",
+            "XAI"
+          ],
+          "type": "string"
+        },
+        "vertexai": {
+          "description": "Provider-specific settings for Vertex AI.",
+          "properties": {
+            "projectId": {
+              "description": "The ID of the Google Cloud Project that you use for the Vertex AI.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "region": {
+              "default": "global",
+              "description": "The location of the Google Cloud Project that you use for the Vertex AI.\nSpecial values: `global` uses the global endpoint, while `us` and `eu` use restricted\nmulti-region endpoints. Other values are treated as regional locations.\nDefaults to `global` if not specified.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "projectId"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "virtualModel": {
+          "description": "Request-time routing among concrete AgentgatewayModel resources.",
+          "properties": {
+            "conditional": {
+              "description": "Ordered condition-based model selection.",
+              "properties": {
+                "targets": {
+                  "description": "Concrete model targets evaluated in order. The first matching condition is\nselected. One final target may omit when to act as the fallback.",
+                  "items": {
+                    "properties": {
+                      "model": {
+                        "description": "Concrete model name selected through the referenced model. It is required\nwhen modelRef points to a wildcard match.model. When omitted, the referenced\nmodel's exact effective match.model is used.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "modelRef": {
+                        "description": "Same-namespace AgentgatewayModel resource selected by this target.",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "when": {
+                        "description": "CEL expression that must evaluate to true for this target to be selected.\nOmit only on the final fallback target.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "modelRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional targets without when must be last",
+                      "rule": "self.filter(e, !has(e.when)).size() <= 1 && (!self.exists(e, !has(e.when)) || !has(self[size(self) - 1].when))"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "targets"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failover": {
+              "description": "Priority-based model selection with failover between priority groups.",
+              "properties": {
+                "targets": {
+                  "description": "Concrete model targets grouped by priority. Lower values are preferred.",
+                  "items": {
+                    "properties": {
+                      "model": {
+                        "description": "Concrete model name selected through the referenced model. It is required\nwhen modelRef points to a wildcard match.model. When omitted, the referenced\nmodel's exact effective match.model is used.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "modelRef": {
+                        "description": "Same-namespace AgentgatewayModel resource selected by this target.",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "priority": {
+                        "description": "Priority of this target. Lower values are preferred. Targets at the same\npriority are selected using a score that considers health and latency. The\nnext priority is used only when every target at this priority is degraded.\nConfigure policies.health on concrete target models to customize\ndegradation and eviction behavior.",
+                        "format": "int32",
+                        "maximum": 1000000,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "modelRef",
+                      "priority"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "targets"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "weighted": {
+              "description": "Weight-based model selection.",
+              "properties": {
+                "targets": {
+                  "description": "Concrete model targets and their relative weights.",
+                  "items": {
+                    "properties": {
+                      "model": {
+                        "description": "Concrete model name selected through the referenced model. It is required\nwhen modelRef points to a wildcard match.model. When omitted, the referenced\nmodel's exact effective match.model is used.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "modelRef": {
+                        "description": "Same-namespace AgentgatewayModel resource selected by this target.",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "default": 1,
+                        "description": "Relative traffic weight. Defaults to 1.",
+                        "format": "int32",
+                        "maximum": 1000000,
+                        "minimum": 1,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "modelRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "targets"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [weighted failover conditional] must be set",
+              "rule": "[has(self.weighted),has(self.failover),has(self.conditional)].filter(x,x==true).size() == 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "visibility": {
+          "default": "Public",
+          "description": "Controls whether clients can request this model directly. Internal models\ncan only be selected by virtual models. Defaults to Public.",
+          "enum": [
+            "Internal",
+            "Public"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "parentRefs"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "baseURL requires provider",
+          "rule": "has(self.provider) || !has(self.baseURL)"
+        },
+        {
+          "message": "policies cannot be used with virtualModel",
+          "rule": "!has(self.virtualModel) || !has(self.policies)"
+        },
+        {
+          "message": "virtual models must be public",
+          "rule": "!has(self.virtualModel) || self.visibility != 'Internal'"
+        },
+        {
+          "message": "virtual model match.model must be an exact name",
+          "rule": "!has(self.virtualModel) || !has(self.match) || !has(self.match.model) || !self.match.model.contains('*')"
+        },
+        {
+          "message": "ollama requires baseURL",
+          "rule": "!has(self.provider) || self.provider != 'Ollama' || has(self.baseURL)"
+        },
+        {
+          "message": "baseURL must be an absolute http or https URL with a host",
+          "rule": "!has(self.baseURL) || (isURL(self.baseURL) && (url(self.baseURL).getScheme() == 'http' || url(self.baseURL).getScheme() == 'https') && url(self.baseURL).getHostname() != \"\")"
+        },
+        {
+          "message": "baseURL cannot target localhost, loopback, or link-local addresses",
+          "rule": "!has(self.baseURL) || !self.baseURL.matches(\"(?i)^https?://(localhost|[^/]+\\\\.localhost)(:[0-9]+)?(/|$)\")"
+        },
+        {
+          "message": "baseURL cannot target localhost, loopback, or link-local addresses",
+          "rule": "!has(self.baseURL) || !self.baseURL.matches(\"^https?://127(\\\\.[0-9]{1,3}){0,3}(:[0-9]+)?(/|$)\")"
+        },
+        {
+          "message": "baseURL cannot target localhost, loopback, or link-local addresses",
+          "rule": "!has(self.baseURL) || !self.baseURL.matches(\"^https?://169\\\\.254\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}(:[0-9]+)?(/|$)\")"
+        },
+        {
+          "message": "baseURL cannot target localhost, loopback, or link-local addresses",
+          "rule": "!has(self.baseURL) || !self.baseURL.matches(\"(?i)^https?://\\\\[(::1|fe[89ab][0-9a-f:]*)\\\\](:[0-9]+)?(/|$)\")"
+        },
+        {
+          "message": "azure must be set if and only if provider is Azure",
+          "rule": "has(self.azure) == (has(self.provider) && self.provider == 'Azure')"
+        },
+        {
+          "message": "vertexai must be set if and only if provider is VertexAI",
+          "rule": "has(self.vertexai) == (has(self.provider) && self.provider == 'VertexAI')"
+        },
+        {
+          "message": "bedrock must be set if and only if provider is Bedrock",
+          "rule": "has(self.bedrock) == (has(self.provider) && self.provider == 'Bedrock')"
+        },
+        {
+          "message": "custom must be set if and only if provider is Custom",
+          "rule": "has(self.custom) == (has(self.provider) && self.provider == 'Custom')"
+        },
+        {
+          "message": "exactly one of the fields in [provider virtualModel] must be set",
+          "rule": "[has(self.provider),has(self.virtualModel)].filter(x,x==true).size() == 1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current model attachment status.",
+      "properties": {
+        "parents": {
+          "description": "Status for each Gateway parent to which this model is attached.",
+          "items": {
+            "description": "RouteParentStatus describes the status of a route with respect to an\nassociated Parent.",
+            "properties": {
+              "conditions": {
+                "description": "Conditions describes the status of the route with respect to the Gateway.\nNote that the route's availability is also subject to the Gateway's own\nstatus conditions and listener status.\n\nIf the Route's ParentRef specifies an existing Gateway that supports\nRoutes of this kind AND that Gateway's controller has sufficient access,\nthen that Gateway's controller MUST set the \"Accepted\" condition on the\nRoute, to indicate whether the route has been accepted or rejected by the\nGateway, and why.\n\nA Route MUST be considered \"Accepted\" if at least one of the Route's\nrules is implemented by the Gateway.\n\nThere are a number of cases where the \"Accepted\" condition may not be set\ndue to lack of controller visibility, that includes when:\n\n* The Route refers to a nonexistent parent.\n* The Route is of a type that the controller does not support.\n* The Route is in a namespace to which the controller does not have access.\n\n<gateway:util:excludeFromCRD>\n\nNotes for implementors:\n\nConditions are a listType `map`, which means that they function like a\nmap with a key of the `type` field _in the k8s apiserver_.\n\nThis means that implementations must obey some rules when updating this\nsection.\n\n* Implementations MUST perform a read-modify-write cycle on this field\n  before modifying it. That is, when modifying this field, implementations\n  must be confident they have fetched the most recent version of this field,\n  and ensure that changes they make are on that recent version.\n* Implementations MUST NOT remove or reorder Conditions that they are not\n  directly responsible for. For example, if an implementation sees a Condition\n  with type `special.io/SomeField`, it MUST NOT remove, change or update that\n  Condition.\n* Implementations MUST always _merge_ changes into Conditions of the same Type,\n  rather than creating more than one Condition of the same Type.\n* Implementations MUST always update the `observedGeneration` field of the\n  Condition to the `metadata.generation` of the Gateway at the time of update creation.\n* If the `observedGeneration` of a Condition is _greater than_ the value the\n  implementation knows about, then it MUST NOT perform the update on that Condition,\n  but must wait for a future reconciliation and status update. (The assumption is that\n  the implementation's copy of the object is stale and an update will be re-triggered\n  if relevant.)\n\n</gateway:util:excludeFromCRD>",
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxItems": 8,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "type"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "controllerName": {
+                "description": "ControllerName is a domain/path string that indicates the name of the\ncontroller that wrote this status. This corresponds with the\ncontrollerName field on GatewayClass.\n\nExample: \"example.net/gateway-controller\".\n\nThe format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are\nvalid Kubernetes names\n(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).\n\nControllers MUST populate this field when writing status. Controllers should ensure that\nentries to status populated with their ControllerName are cleaned up when they are no\nlonger necessary.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\\/[A-Za-z0-9\\/\\-._~%!$&'()*+,;=:]+$",
+                "type": "string"
+              },
+              "parentRef": {
+                "description": "ParentRef corresponds with a ParentRef in the spec that this\nRouteParentStatus struct describes the status of.",
+                "properties": {
+                  "group": {
+                    "default": "gateway.networking.k8s.io",
+                    "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "default": "Gateway",
+                    "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the referent.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. Defaults to the Route's local namespace. Cross-namespace references must be explicitly allowed, for example via ReferenceGrant. Support: Core",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port this Route targets on the parent, interpreted per parent kind (for example a Gateway listener port or Service port). Support: Extended",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "sectionName": {
+                    "description": "Name of a section within the target resource, for example a Gateway Listener name or Service port name. Empty references the entire resource. Support: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "conditions",
+              "controllerName",
+              "parentRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 16,
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/agentgateway.dev/agentgatewayparameters_v1alpha1.json
+++ b/agentgateway.dev/agentgatewayparameters_v1alpha1.json
@@ -15,6 +15,37 @@
     "spec": {
       "description": "Desired data plane provisioning settings.",
       "properties": {
+        "daemonSet": {
+          "description": "Overrides for the generated\n`DaemonSet` resource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
         "deployment": {
           "description": "Overrides for the generated\n`Deployment` resource.",
           "properties": {
@@ -36,8 +67,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -45,8 +75,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "env": {
           "description": "Container environment variables. These override any existing\nvalues. If you want to delete an environment variable entirely, use\n`$patch: delete` with an overlay instead. Note that\n[variable\nexpansion](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/)\ndoes apply, but is highly discouraged -- to set dependent environment\nvariables, you can use `$(VAR_NAME)`, but it's highly discouraged.\n`$$(VAR_NAME)` avoids expansion and results in a literal\n`$(VAR_NAME)`.\n\nIf `SESSION_KEY` is specified, it takes precedence over the\ncontroller-managed per-`Gateway` session key `Secret`.",
@@ -73,7 +102,7 @@
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "description": "Name of the referent",
                         "type": "string"
                       },
                       "optional": {
@@ -85,8 +114,7 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "fieldRef": {
                     "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -104,8 +132,7 @@
                       "fieldPath"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "fileKeyRef": {
                     "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
@@ -134,8 +161,7 @@
                       "volumeName"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "resourceFieldRef": {
                     "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -166,8 +192,7 @@
                       "resource"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "secretKeyRef": {
                     "description": "Selects a key of a secret in the pod's namespace",
@@ -178,7 +203,7 @@
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "description": "Name of the referent",
                         "type": "string"
                       },
                       "optional": {
@@ -190,24 +215,21 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
         "horizontalPodAutoscaler": {
-          "description": "Creates a `HorizontalPodAutoscaler`\nfor the agentgateway proxy. If absent, no HPA is created. If present, an\nHPA is created with its `scaleTargetRef` automatically configured to\ntarget the agentgateway proxy `Deployment`. The `metadata` and `spec`\nfields from this overlay are applied to the generated HPA.",
+          "description": "Creates a `HorizontalPodAutoscaler`\nfor Deployment-backed agentgateway proxies. If absent, no HPA is created.\nIf present, an HPA is created with its `scaleTargetRef` automatically\nconfigured to target the generated `Deployment`. The `metadata` and `spec`\nfields from this overlay are applied to the generated HPA.",
           "properties": {
             "metadata": {
               "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
@@ -227,8 +249,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -236,8 +257,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "image": {
           "description": "The agentgateway container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: cr.agentgateway.dev\n\trepository: agentgateway\n\ttag: <agentgateway version>\n\tpullPolicy: <omitted, relying on Kubernetes defaults which depend on the tag>",
@@ -263,8 +283,7 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "istio": {
           "description": "Istio integration settings. If enabled, agentgateway can natively connect to Istio-enabled pods with mTLS.",
@@ -297,8 +316,7 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "logging": {
           "description": "Logging configuration. By default, all logs are set to\n`info` level.",
@@ -316,8 +334,7 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "modelCatalog": {
           "description": "Model cost catalog sources. Only effective when set on a Gateway-level\nAgentgatewayParameters (via Gateway.spec.infrastructure.parametersRef);\nignored on GatewayClass-level parameters because ConfigMap references\nare resolved from the Gateway's deployment namespace.",
@@ -341,21 +358,18 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "podDisruptionBudget": {
-          "description": "Creates a `PodDisruptionBudget` for the\nagentgateway proxy. If absent, no PDB is created. If present, a PDB is\ncreated with its selector automatically configured to target the\nagentgateway proxy `Deployment`. The `metadata` and `spec` fields from\nthis overlay are applied to the generated PDB.",
+          "description": "Creates a `PodDisruptionBudget` for the\nagentgateway proxy. If absent, no PDB is created. If present, a PDB is\ncreated with its selector automatically configured to target the selected\ngenerated workload. The `metadata` and `spec` fields from this overlay are\napplied to the generated PDB.",
           "properties": {
             "metadata": {
               "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
@@ -375,8 +389,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -384,8 +397,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "rawConfig": {
           "description": "Raw agentgateway configuration to merge into the generated config file.\nThis is merged with\nconfiguration derived from typed fields like `logging.format`, and those\ntyped fields will take precedence.\n\nExample:\n\n\trawConfig:\n\t  binds:\n\t  - port: 3000\n\t    listeners:\n\t    - routes:\n\t      - policies:\n\t          cors:\n\t            allowOrigins:\n\t            - \"*\"\n\t            allowHeaders:\n\t            - mcp-protocol-version\n\t            - content-type\n\t            - cache-control\n\t        backends:\n\t        - mcp:\n\t            targets:\n\t            - name: everything\n\t              stdio:\n\t                cmd: npx\n\t                args: [\"@modelcontextprotocol/server-everything\"]",
@@ -412,8 +424,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -454,8 +465,7 @@
               "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "service": {
           "description": "Overrides for the generated `Service`\nresource.",
@@ -478,8 +488,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -487,8 +496,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "serviceAccount": {
           "description": "Overrides for the generated\n`ServiceAccount` resource.",
@@ -511,8 +519,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -520,8 +527,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "shutdown": {
           "description": "Shutdown delay configuration. How graceful planned or unplanned data\nplane changes happen is in tension with how quickly rollouts of the data\nplane complete. How long a data plane pod must wait for shutdown to be\nperfectly graceful depends on how you have configured your `Gateway`\nresources.",
@@ -551,12 +557,38 @@
               "message": "The 'min' value must be less than or equal to the 'max' value.",
               "rule": "self.min <= self.max"
             }
-          ],
-          "additionalProperties": false
+          ]
+        },
+        "workload": {
+          "description": "`workload` selects the Kubernetes workload kind for the managed Gateway\ndata plane. If unset, Deployment is used.",
+          "properties": {
+            "kind": {
+              "description": "Kind selects the Kubernetes workload kind. When unset, Deployment is used.",
+              "enum": [
+                "DaemonSet",
+                "Deployment"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object",
-      "additionalProperties": false
+      "x-kubernetes-validations": [
+        {
+          "message": "deployment overlays are only valid when workload.kind is Deployment or unset",
+          "rule": "!has(self.deployment) || !has(self.workload) || !has(self.workload.kind) || self.workload.kind == 'Deployment'"
+        },
+        {
+          "message": "daemonSet overlays are only valid when workload.kind is DaemonSet",
+          "rule": "!has(self.daemonSet) || (has(self.workload) && has(self.workload.kind) && self.workload.kind == 'DaemonSet')"
+        },
+        {
+          "message": "horizontalPodAutoscaler is not valid when workload.kind is DaemonSet",
+          "rule": "!has(self.horizontalPodAutoscaler) || !has(self.workload) || !has(self.workload.kind) || self.workload.kind != 'DaemonSet'"
+        }
+      ]
     },
     "status": {
       "description": "Current status for these provisioning settings.",

--- a/agentgateway.dev/agentgatewayparameters_v1alpha1.json
+++ b/agentgateway.dev/agentgatewayparameters_v1alpha1.json
@@ -36,7 +36,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -44,7 +45,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "deployment": {
           "description": "Overrides for the generated\n`Deployment` resource.",
@@ -67,7 +69,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -75,7 +78,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "env": {
           "description": "Container environment variables. These override any existing\nvalues. If you want to delete an environment variable entirely, use\n`$patch: delete` with an overlay instead. Note that\n[variable\nexpansion](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/)\ndoes apply, but is highly discouraged -- to set dependent environment\nvariables, you can use `$(VAR_NAME)`, but it's highly discouraged.\n`$$(VAR_NAME)` avoids expansion and results in a literal\n`$(VAR_NAME)`.\n\nIf `SESSION_KEY` is specified, it takes precedence over the\ncontroller-managed per-`Gateway` session key `Secret`.",
@@ -114,7 +118,8 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "fieldRef": {
                     "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -132,7 +137,8 @@
                       "fieldPath"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "fileKeyRef": {
                     "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
@@ -161,7 +167,8 @@
                       "volumeName"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "resourceFieldRef": {
                     "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -192,7 +199,8 @@
                       "resource"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "secretKeyRef": {
                     "description": "Selects a key of a secret in the pod's namespace",
@@ -215,16 +223,19 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "required": [
               "name"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -249,7 +260,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -257,7 +269,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "image": {
           "description": "The agentgateway container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: cr.agentgateway.dev\n\trepository: agentgateway\n\ttag: <agentgateway version>\n\tpullPolicy: <omitted, relying on Kubernetes defaults which depend on the tag>",
@@ -283,7 +296,8 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "istio": {
           "description": "Istio integration settings. If enabled, agentgateway can natively connect to Istio-enabled pods with mTLS.",
@@ -316,7 +330,8 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "logging": {
           "description": "Logging configuration. By default, all logs are set to\n`info` level.",
@@ -334,7 +349,8 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "modelCatalog": {
           "description": "Model cost catalog sources. Only effective when set on a Gateway-level\nAgentgatewayParameters (via Gateway.spec.infrastructure.parametersRef);\nignored on GatewayClass-level parameters because ConfigMap references\nare resolved from the Gateway's deployment namespace.",
@@ -358,15 +374,18 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "podDisruptionBudget": {
           "description": "Creates a `PodDisruptionBudget` for the\nagentgateway proxy. If absent, no PDB is created. If present, a PDB is\ncreated with its selector automatically configured to target the selected\ngenerated workload. The `metadata` and `spec` fields from this overlay are\napplied to the generated PDB.",
@@ -389,7 +408,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -397,7 +417,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "rawConfig": {
           "description": "Raw agentgateway configuration to merge into the generated config file.\nThis is merged with\nconfiguration derived from typed fields like `logging.format`, and those\ntyped fields will take precedence.\n\nExample:\n\n\trawConfig:\n\t  binds:\n\t  - port: 3000\n\t    listeners:\n\t    - routes:\n\t      - policies:\n\t          cors:\n\t            allowOrigins:\n\t            - \"*\"\n\t            allowHeaders:\n\t            - mcp-protocol-version\n\t            - content-type\n\t            - cache-control\n\t        backends:\n\t        - mcp:\n\t            targets:\n\t            - name: everything\n\t              stdio:\n\t                cmd: npx\n\t                args: [\"@modelcontextprotocol/server-everything\"]",
@@ -424,7 +445,8 @@
                 "required": [
                   "name"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -465,7 +487,8 @@
               "type": "object"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "service": {
           "description": "Overrides for the generated `Service`\nresource.",
@@ -488,7 +511,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -496,7 +520,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "serviceAccount": {
           "description": "Overrides for the generated\n`ServiceAccount` resource.",
@@ -519,7 +544,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
@@ -527,7 +553,8 @@
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "shutdown": {
           "description": "Shutdown delay configuration. How graceful planned or unplanned data\nplane changes happen is in tension with how quickly rollouts of the data\nplane complete. How long a data plane pod must wait for shutdown to be\nperfectly graceful depends on how you have configured your `Gateway`\nresources.",
@@ -557,7 +584,8 @@
               "message": "The 'min' value must be less than or equal to the 'max' value.",
               "rule": "self.min <= self.max"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "workload": {
           "description": "`workload` selects the Kubernetes workload kind for the managed Gateway\ndata plane. If unset, Deployment is used.",
@@ -571,7 +599,8 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -588,7 +617,8 @@
           "message": "horizontalPodAutoscaler is not valid when workload.kind is DaemonSet",
           "rule": "!has(self.horizontalPodAutoscaler) || !has(self.workload) || !has(self.workload.kind) || self.workload.kind != 'DaemonSet'"
         }
-      ]
+      ],
+      "additionalProperties": false
     },
     "status": {
       "description": "Current status for these provisioning settings.",

--- a/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
@@ -40,7 +40,8 @@
                       "field",
                       "value"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -74,7 +75,8 @@
                       "field",
                       "value"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -101,7 +103,8 @@
                           "content",
                           "role"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -123,12 +126,14 @@
                           "content",
                           "role"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "promptCaching": {
                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -156,12 +161,13 @@
                     },
                     "minTokens": {
                       "default": 1024,
-                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                       "minimum": 0,
                       "type": "integer"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "promptGuard": {
                   "description": "Guardrails for LLM requests and responses.",
@@ -241,7 +247,8 @@
                                                       "message": "exactly one of value or expression must be set",
                                                       "rule": "has(self.value) != has(self.expression)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "maxItems": 50,
                                                 "type": "array",
@@ -260,7 +267,8 @@
                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "region": {
                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -296,7 +304,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -311,7 +320,8 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "key": {
                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -332,7 +342,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -352,7 +363,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -365,7 +377,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -374,7 +387,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -410,7 +424,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -423,7 +438,8 @@
                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -452,7 +468,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -513,10 +530,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -544,7 +563,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -601,7 +621,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -640,7 +661,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -693,13 +715,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -708,7 +732,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -728,7 +753,8 @@
                               "region",
                               "version"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -789,7 +815,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -806,7 +833,8 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -815,7 +843,8 @@
                                         "message": "exactly one of the fields in [gcp] must be set",
                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -844,7 +873,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -905,10 +935,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -936,7 +968,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -993,7 +1026,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -1032,7 +1066,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -1085,13 +1120,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -1100,7 +1137,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -1119,7 +1157,8 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "openAIModeration": {
                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -1153,7 +1192,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -1173,7 +1213,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -1186,7 +1227,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -1195,7 +1237,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -1231,7 +1274,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -1240,7 +1284,8 @@
                                         "message": "exactly one of the fields in [key secretRef] must be set",
                                         "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -1269,7 +1314,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -1330,10 +1376,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -1361,7 +1409,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -1418,7 +1467,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -1457,7 +1507,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -1510,13 +1561,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -1525,10 +1578,12 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -1567,7 +1622,8 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -1592,7 +1648,8 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "webhook": {
                             "description": "Webhook that receives requests for prompt guarding.",
@@ -1645,7 +1702,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -1687,7 +1745,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               },
@@ -1706,7 +1765,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -1715,7 +1775,8 @@
                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -1796,7 +1857,8 @@
                                                       "message": "exactly one of value or expression must be set",
                                                       "rule": "has(self.value) != has(self.expression)"
                                                     }
-                                                  ]
+                                                  ],
+                                                  "additionalProperties": false
                                                 },
                                                 "maxItems": 50,
                                                 "type": "array",
@@ -1815,7 +1877,8 @@
                                                 "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                                                 "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "region": {
                                             "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -1851,7 +1914,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -1866,7 +1930,8 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "key": {
                                         "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
@@ -1887,7 +1952,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "header": {
                                             "properties": {
@@ -1907,7 +1973,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -1920,7 +1987,8 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
                                         },
                                         "type": "object",
@@ -1929,7 +1997,8 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       },
                                       "secretRef": {
                                         "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
@@ -1965,7 +2034,8 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -1978,7 +2048,8 @@
                                         "message": "exactly one of the fields in [key secretRef aws] must be set",
                                         "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -2007,7 +2078,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -2068,10 +2140,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -2099,7 +2173,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -2156,7 +2231,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -2195,7 +2271,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -2248,13 +2325,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -2263,7 +2342,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -2283,7 +2363,8 @@
                               "region",
                               "version"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -2344,7 +2425,8 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ]
+                                            ],
+                                            "additionalProperties": false
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -2361,7 +2443,8 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "type": "object",
@@ -2370,7 +2453,8 @@
                                         "message": "exactly one of the fields in [gcp] must be set",
                                         "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "http": {
                                     "description": "Settings for managing HTTP requests to the backend",
@@ -2399,7 +2483,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tcp": {
                                     "description": "Settings for managing TCP connections to the backend",
@@ -2460,10 +2545,12 @@
                                             ]
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "tls": {
                                     "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -2491,7 +2578,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -2548,7 +2636,8 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ]
+                                          ],
+                                          "additionalProperties": false
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -2587,7 +2676,8 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ]
+                                    ],
+                                    "additionalProperties": false
                                   },
                                   "tunnel": {
                                     "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -2640,13 +2730,15 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ]
+                                        ],
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   }
                                 },
                                 "type": "object",
@@ -2655,7 +2747,8 @@
                                     "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
                                     "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -2674,7 +2767,8 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -2713,7 +2807,8 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -2738,7 +2833,8 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "webhook": {
                             "description": "Webhook that receives responses for prompt guarding.",
@@ -2791,7 +2887,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -2833,7 +2930,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               },
@@ -2852,7 +2950,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -2861,7 +2960,8 @@
                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -2881,7 +2981,8 @@
                       "message": "at least one of the fields in [request response] must be set",
                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "routes": {
                   "additionalProperties": {
@@ -2925,7 +3026,8 @@
                       "expression",
                       "field"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -2938,7 +3040,8 @@
                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "auth": {
               "description": "Settings for managing authentication to the backend",
@@ -2998,7 +3101,8 @@
                                 "message": "exactly one of value or expression must be set",
                                 "rule": "has(self.value) != has(self.expression)"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "maxItems": 50,
                           "type": "array",
@@ -3017,7 +3121,8 @@
                           "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
                           "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "region": {
                       "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
@@ -3053,7 +3158,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "serviceName": {
                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -3068,7 +3174,8 @@
                       "message": "secretRef and assumeRole are mutually exclusive",
                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "azure": {
                   "description": "Azure authentication method for the backend.",
@@ -3091,7 +3198,8 @@
                         "objectId",
                         "resourceId"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "secretRef": {
                       "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
@@ -3121,7 +3229,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "workloadIdentity": {
                       "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
@@ -3134,7 +3243,8 @@
                       "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
                       "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "credentials": {
                   "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
@@ -3155,7 +3265,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "header": {
                             "properties": {
@@ -3175,7 +3286,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "queryParameter": {
                             "properties": {
@@ -3188,7 +3300,8 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -3197,7 +3310,8 @@
                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "secretRef": {
                         "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
@@ -3233,14 +3347,16 @@
                             "message": "custom credential refs must set both group and kind",
                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "location",
                       "secretRef"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 8,
                   "minItems": 1,
@@ -3271,10 +3387,12 @@
                               "type": "integer"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "identityProvider": {
                       "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
@@ -3327,7 +3445,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "clientAuth": {
                           "description": "Client authentication for the token endpoint.",
@@ -3408,7 +3527,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "kid": {
                                   "description": "Optional JWS key ID header.",
@@ -3448,7 +3568,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
@@ -3461,7 +3582,8 @@
                                   "message": "certificateRef and certificateHeader must be set together",
                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "secretRef": {
                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -3497,7 +3619,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -3517,7 +3640,8 @@
                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "path": {
                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -3529,7 +3653,8 @@
                         "backendRef",
                         "clientAuth"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "resourceAuthorizationServer": {
                       "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
@@ -3582,7 +3707,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "clientAuth": {
                           "description": "Client authentication for the token endpoint.",
@@ -3663,7 +3789,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "kid": {
                                   "description": "Optional JWS key ID header.",
@@ -3703,7 +3830,8 @@
                                       "message": "custom credential refs must set both group and kind",
                                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                     }
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
@@ -3716,7 +3844,8 @@
                                   "message": "certificateRef and certificateHeader must be set together",
                                   "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "secretRef": {
                               "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -3752,7 +3881,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -3772,7 +3902,8 @@
                               "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                               "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "path": {
                           "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -3784,7 +3915,8 @@
                         "backendRef",
                         "clientAuth"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "resources": {
                       "description": "Resources sent to the token endpoint.",
@@ -3821,7 +3953,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -3847,7 +3980,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -3860,7 +3994,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -3869,10 +4004,12 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -3880,7 +4017,8 @@
                     "identityProvider",
                     "resourceAuthorizationServer"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "gcp": {
                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -3925,7 +4063,8 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "type": {
                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -3942,7 +4081,8 @@
                       "message": "audience is only valid with IdToken",
                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "key": {
                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -3963,7 +4103,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "header": {
                       "properties": {
@@ -3983,7 +4124,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "queryParameter": {
                       "properties": {
@@ -3996,7 +4138,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -4005,7 +4148,8 @@
                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "oauthTokenExchange": {
                   "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
@@ -4034,7 +4178,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -4060,7 +4205,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -4073,7 +4219,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -4082,7 +4229,8 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "tokenType": {
                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
@@ -4098,7 +4246,8 @@
                           "message": "mayAct Required requires tokenType Jwt",
                           "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "additionalParams": {
                       "additionalProperties": {
@@ -4170,7 +4319,8 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "cache": {
                       "description": "Response cache configuration.",
@@ -4187,10 +4337,12 @@
                               "type": "integer"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "clientAuth": {
                       "description": "Client authentication for the token endpoint. When unset, none is sent.",
@@ -4271,7 +4423,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "kid": {
                               "description": "Optional JWS key ID header.",
@@ -4311,7 +4464,8 @@
                                   "message": "custom credential refs must set both group and kind",
                                   "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           },
                           "required": [
@@ -4324,7 +4478,8 @@
                               "message": "certificateRef and certificateHeader must be set together",
                               "rule": "has(self.certificateRef) == has(self.certificateHeader)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "secretRef": {
                           "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
@@ -4360,7 +4515,8 @@
                               "message": "custom credential refs must set both group and kind",
                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         }
                       },
                       "required": [
@@ -4380,7 +4536,8 @@
                           "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
                           "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "grantType": {
                       "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
@@ -4404,7 +4561,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "header": {
                           "properties": {
@@ -4424,7 +4582,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "queryParameter": {
                           "properties": {
@@ -4437,7 +4596,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "type": "object",
@@ -4446,7 +4606,8 @@
                           "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                           "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "path": {
                       "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
@@ -4498,7 +4659,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "expression": {
                               "description": "CEL expression that extracts the credential from the request.",
@@ -4524,7 +4686,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "queryParameter": {
                               "properties": {
@@ -4537,7 +4700,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "type": "object",
@@ -4546,14 +4710,16 @@
                               "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                               "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "tokenType": {
                           "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -4573,7 +4739,8 @@
                       "message": "requestedTokenType IdJag is only supported by crossAppAccess",
                       "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "passthrough": {
                   "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
@@ -4613,7 +4780,8 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -4630,7 +4798,8 @@
                   "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
                   "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "extAuth": {
               "description": "External authentication configuration for requests\nsent to this backend.",
@@ -4683,7 +4852,8 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "cache": {
                   "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
@@ -4717,7 +4887,8 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "failureMode": {
                   "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -4755,7 +4926,8 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -4780,7 +4952,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -4846,7 +5019,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -4855,7 +5029,8 @@
                   "message": "forwardBody cannot be used with http.body",
                   "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "health": {
               "description": "Settings for passive and active health checking.",
@@ -4900,7 +5075,8 @@
                       "type": "integer"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "unhealthyCondition": {
                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -4909,7 +5085,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "http": {
               "description": "Settings for managing HTTP requests to the backend",
@@ -4938,7 +5115,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "mcp": {
               "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
@@ -4947,7 +5125,7 @@
                   "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
                   "properties": {
                     "audiences": {
-                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                       "items": {
                         "type": "string"
                       },
@@ -4993,10 +5171,11 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "issuer": {
-                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                       "maxLength": 256,
                       "minLength": 1,
                       "type": "string"
@@ -5052,7 +5231,8 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ]
+                          ],
+                          "additionalProperties": false
                         },
                         "cacheDuration": {
                           "default": "5m",
@@ -5080,7 +5260,8 @@
                         "backendRef",
                         "jwksPath"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mode": {
                       "default": "Strict",
@@ -5115,7 +5296,8 @@
                   "required": [
                     "jwks"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "authorization": {
                   "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
@@ -5149,13 +5331,15 @@
                       "required": [
                         "matchExpressions"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "required": [
                     "policy"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "guardrails": {
                   "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
@@ -5257,7 +5441,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "disallowedRequestHeaders": {
                                 "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
@@ -5301,7 +5486,8 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "required": [
@@ -5313,7 +5499,8 @@
                             "message": "exactly one of the fields in [remote] must be set",
                             "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5323,7 +5510,8 @@
                   "required": [
                     "processors"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -5332,7 +5520,8 @@
                   "message": "at least one of the fields in [authentication authorization guardrails] must be set",
                   "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tcp": {
               "description": "Settings for managing TCP connections to the backend",
@@ -5393,10 +5582,12 @@
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "tls": {
               "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
@@ -5424,7 +5615,8 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -5481,7 +5673,8 @@
                         "message": "custom credential refs must set both group and kind",
                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                       }
-                    ]
+                    ],
+                    "additionalProperties": false
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -5520,7 +5713,8 @@
                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -5556,7 +5750,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5632,7 +5827,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5649,7 +5845,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -5682,7 +5879,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5758,7 +5956,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5775,7 +5974,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -5784,7 +5984,8 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tunnel": {
               "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
@@ -5837,13 +6038,15 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "required": [
                 "backendRef"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -5852,7 +6055,8 @@
               "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
               "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "frontend": {
           "description": "Settings for how to handle incoming traffic.\n\nA frontend policy can only target a `Gateway`. `Listener` and\n`ListenerSet` are not valid targets.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. For example, policy A sets `tcp` and `tls`, and policy B sets\n`tls`; the effective policy would be `tcp` from policy A, and `tls` from\npolicy B.",
@@ -5883,7 +6087,8 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "minItems": 1,
                       "type": "array"
@@ -5906,7 +6111,8 @@
                       "message": "at least one of the fields in [add remove] must be set",
                       "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "filter": {
                   "description": "CEL expression used to filter logs. A log\nwill only be emitted if the expression evaluates to `true`.",
@@ -5940,7 +6146,8 @@
                               "expression",
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "minItems": 1,
                           "type": "array"
@@ -5963,7 +6170,8 @@
                           "message": "at least one of the fields in [add remove] must be set",
                           "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "backendRef": {
                       "description": "OTLP server to send access logs to.\nSupported types: `Service` and `AgentgatewayBackend`.",
@@ -6013,7 +6221,8 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "filter": {
                       "description": "CEL expression used to filter OTLP logs. A log\nwill only be exported if the expression evaluates to `true`.\nIf unset, the parent access log filter is used.",
@@ -6050,10 +6259,12 @@
                       "message": "path must start with /",
                       "rule": "!has(self.path) || self.path.startsWith('/')"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "connect": {
               "description": "Settings for downstream HTTP CONNECT handling.\n\nIf unset, CONNECT requests are rejected with Method Not Allowed.",
@@ -6071,7 +6282,8 @@
               "required": [
                 "mode"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "http": {
               "description": "Settings for managing incoming HTTP requests.",
@@ -6269,7 +6481,8 @@
                   "message": "at least one of the fields in [http1HeaderCase http1IdleTimeout http1MaxHeaders http2ConnectionWindowSize http2FrameSize http2KeepaliveInterval http2KeepaliveTimeout http2MaxHeaderSize http2WindowSize maxBufferSize maxConnectionDuration] must be set",
                   "rule": "[has(self.http1HeaderCase),has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConnectionDuration)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "metrics": {
               "description": "Custom Prometheus metric label configuration.\nCEL expressions are evaluated per-request and added as labels to all\nPrometheus metrics exposed by agentgateway.",
@@ -6297,7 +6510,8 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -6314,13 +6528,15 @@
                       "message": "at least one of the fields in [add] must be set",
                       "rule": "[has(self.add)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "required": [
                 "attributes"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "networkAuthorization": {
               "description": "CEL authorization on downstream network connections.\n\nThis runs before protocol handling and is intended for L4 access control,\nfor example using `source.address` with `cidr(...).containsIP(...)`.",
@@ -6354,13 +6570,15 @@
                   "required": [
                     "matchExpressions"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "required": [
                 "policy"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "proxyProtocol": {
               "description": "Settings for downstream PROXY protocol handling.\n\nIf configured, incoming connections may require a PROXY header before\nnormal protocol handling. This can also be configured to allow both\nPROXY and non-PROXY traffic on the same listener.",
@@ -6385,7 +6603,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "tcp": {
               "description": "Settings for managing incoming TCP connections.",
@@ -6431,7 +6650,8 @@
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -6440,7 +6660,8 @@
                   "message": "at least one of the fields in [keepalive] must be set",
                   "rule": "[has(self.keepalive)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tls": {
               "description": "Settings for managing incoming TLS connections.",
@@ -6525,7 +6746,8 @@
                   "message": "at least one of the fields in [alpnProtocols cipherSuites handshakeTimeout keyExchangeGroups maxProtocolVersion minProtocolVersion] must be set",
                   "rule": "[has(self.alpnProtocols),has(self.cipherSuites),has(self.handshakeTimeout),has(self.keyExchangeGroups),has(self.maxProtocolVersion),has(self.minProtocolVersion)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "tracing": {
               "description": "OpenTelemetry tracing settings.",
@@ -6553,7 +6775,8 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "minItems": 1,
                       "type": "array"
@@ -6576,7 +6799,8 @@
                       "message": "at least one of the fields in [add remove] must be set",
                       "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "backendRef": {
                   "description": "OTLP server to reach.\nSupported types: `Service` and `AgentgatewayBackend`.",
@@ -6626,7 +6850,8 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "clientSampling": {
                   "description": "Expression that determines the amount of client\nsampling. Client sampling determines whether to initiate a new trace\nspan if the incoming request does have a trace already. This should\nevaluate to a float between `0.0` and `1.0`, or a boolean (`true` or\n`false`). If unspecified, client sampling is `100%` enabled.",
@@ -6681,7 +6906,8 @@
                       "expression",
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array"
                 }
@@ -6699,7 +6925,8 @@
                   "message": "path must start with /",
                   "rule": "!has(self.path) || self.path.startsWith('/')"
                 }
-              ]
+              ],
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -6708,7 +6935,8 @@
               "message": "at least one of the fields in [accessLog connect http metrics networkAuthorization proxyProtocol tcp tls tracing] must be set",
               "rule": "[has(self.accessLog),has(self.connect),has(self.http),has(self.metrics),has(self.networkAuthorization),has(self.proxyProtocol),has(self.tcp),has(self.tls),has(self.tracing)].filter(x,x==true).size() >= 1"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "strategy": {
           "description": "Policy merge and conflict resolution strategy.\n\nStrategy settings apply to the policy object as a whole. Individual strategy fields may\nonly be valid for specific policy kinds; for example, inheritance is only valid when this\npolicy contains traffic settings.",
@@ -6722,7 +6950,8 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "targetRefs": {
           "description": "Target resources to attach the\npolicy to.",
@@ -6774,7 +7003,8 @@
                 "message": "at most one of the fields in [sectionName port] may be set",
                 "rule": "[has(self.sectionName),has(self.port)].filter(x,x==true).size() <= 1"
               }
-            ]
+            ],
+            "additionalProperties": false
           },
           "maxItems": 16,
           "minItems": 1,
@@ -6842,7 +7072,8 @@
                 "message": "at most one of the fields in [sectionName port] may be set",
                 "rule": "[has(self.sectionName),has(self.port)].filter(x,x==true).size() <= 1"
               }
-            ]
+            ],
+            "additionalProperties": false
           },
           "maxItems": 16,
           "minItems": 1,
@@ -6878,7 +7109,8 @@
                   "required": [
                     "matchLabels"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "location": {
                   "description": "Where API keys are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
@@ -6894,7 +7126,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -6920,7 +7153,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "queryParameter": {
                       "properties": {
@@ -6933,7 +7167,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -6942,7 +7177,8 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "mode": {
                   "default": "Strict",
@@ -6982,7 +7218,8 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "secretSelector": {
                   "description": "Selects multiple Kubernetes `Secret` resources\ncontaining API keys. It is Secret-only; use `secretRef` for other\ncredential kinds. If the same key is defined in multiple secrets, the\nbehavior is undefined.\n\nEach entry in the `Secret` data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with `key` or `keyHash`, plus optional `metadata`.\n  `key` contains the API key. `keyHash` contains a hashed API key in\n  `sha256:<hex>` format. `metadata` contains arbitrary JSON metadata\n  associated with the key, which may be used by other policies. For\n  example, you may write an authorization policy allowing\n  `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
@@ -6998,7 +7235,8 @@
                   "required": [
                     "matchLabels"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -7007,7 +7245,8 @@
                   "message": "exactly one of the fields in [secretRef secretSelector configMapSelector] must be set",
                   "rule": "[has(self.secretRef),has(self.secretSelector),has(self.configMapSelector)].filter(x,x==true).size() == 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "authorization": {
               "description": "Access rules based on roles and\npermissions.\nIf multiple authorization rules are applied across different policies, at the same or different attachment points,\nall rules are merged.",
@@ -7041,13 +7280,15 @@
                   "required": [
                     "matchExpressions"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "required": [
                 "policy"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "basicAuthentication": {
               "description": "Authenticates users based on the `Basic`\nauthentication scheme (RFC 7617), where a username and password are\nencoded in the request.",
@@ -7066,7 +7307,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -7092,7 +7334,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "queryParameter": {
                       "properties": {
@@ -7105,7 +7348,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -7114,7 +7358,8 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "mode": {
                   "default": "Strict",
@@ -7163,7 +7408,8 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "users": {
                   "description": "Inline list of username and password pairs that will\nbe accepted. Each entry represents one line of the `htpasswd` format:\nhttps://httpd.apache.org/docs/2.4/programs/htpasswd.html.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tusers:\n\t- \"user1:$apr1$ivPt0D4C$DmRhnewfHRSrb3DQC.WHC.\"\n\t- \"user2:$2y$05$r3J4d3VepzFkedkd/q1vI.pBYIpSqjfN0qOARV3ScUHysatnS0cL2\"",
@@ -7181,7 +7427,8 @@
                   "message": "exactly one of the fields in [users secretRef] must be set",
                   "rule": "[has(self.users),has(self.secretRef)].filter(x,x==true).size() == 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "buffer": {
               "description": "Buffers request and response bodies. Buffered bodies are accumulated in memory\nby the proxy until completion before being forwarded. This changes the proxies default behavior, which streams bodies.\n\nWarning: large bodies can lead to excessive memory usage in the proxy. Utilize with care, or with strict limits.",
@@ -7219,7 +7466,8 @@
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "response": {
                   "description": "Response body buffering settings.",
@@ -7254,7 +7502,8 @@
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -7263,7 +7512,8 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "cors": {
               "description": "CORS configuration for the policy.",
@@ -7359,7 +7609,8 @@
                 }
               },
               "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "x-kubernetes-preserve-unknown-fields": true,
+              "additionalProperties": false
             },
             "csrf": {
               "description": "Cross-Site Request Forgery (CSRF) policy for this traffic policy.\n\nThe CSRF policy has the following behavior:\n* Safe methods (`GET`, `HEAD`, `OPTIONS`) are automatically allowed.\n* Requests without `Sec-Fetch-Site` or `Origin` headers are assumed to\n  be same-origin or non-browser requests and are allowed.\n* Otherwise, the `Sec-Fetch-Site` header is checked, with a fallback to\n  comparing the `Origin` header to the `Host` header.",
@@ -7376,7 +7627,8 @@
                   "type": "array"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "delay": {
               "description": "Injects artificial latency before forwarding requests, for\nfault-injection testing.",
@@ -7391,7 +7643,8 @@
               "required": [
                 "duration"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "directResponse": {
               "description": "Sends a direct response to the\nclient.",
@@ -7455,7 +7708,8 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -7483,13 +7737,15 @@
                             "message": "body and bodyExpression may not both be set",
                             "rule": "!(has(self.body) && has(self.bodyExpression))"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -7523,7 +7779,8 @@
                       "name",
                       "value"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -7555,7 +7812,8 @@
                   "message": "status: Required value",
                   "rule": "has(self.conditional) ? true : has(self.status)"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "extAuth": {
               "description": "External authentication configuration for the policy.\nThis selects the external server to send requests to for authentication.\n\nAn extAuth policy can be conditionally set by nesting configuration under the `conditional` field.",
@@ -7608,7 +7866,8 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "cache": {
                   "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
@@ -7642,7 +7901,8 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "conditional": {
                   "description": "Conditional policy execution. Set this or the top-level extAuth fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
@@ -7705,7 +7965,8 @@
                                 "message": "Must have port for Service reference",
                                 "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "cache": {
                             "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
@@ -7739,7 +8000,8 @@
                               "key",
                               "ttl"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureMode": {
                             "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -7777,7 +8039,8 @@
                             "required": [
                               "maxSize"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "grpc": {
                             "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -7802,7 +8065,8 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "http": {
                             "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -7868,7 +8132,8 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -7885,13 +8150,15 @@
                             "message": "forwardBody cannot be used with http.body",
                             "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -7939,7 +8206,8 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -7964,7 +8232,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -8030,7 +8299,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -8051,7 +8321,8 @@
                   "message": "backendRef: Required value",
                   "rule": "has(self.conditional) ? true : has(self.backendRef)"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "extProc": {
               "description": "External processing configuration for the policy.",
@@ -8104,7 +8375,8 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "conditional": {
                   "description": "Conditional policy execution. Set this or the top-level extProc fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
@@ -8167,7 +8439,8 @@
                                 "message": "Must have port for Service reference",
                                 "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "failureMode": {
                             "description": "Behavior when the external processor is unavailable or returns an error.\n\"FailOpen\" allows the request to continue, as long as the request body has not\nbeen sent (or started streaming) to the ext_proc. Once the request body has\nstarted streaming to the ext_proc, the request will fail closed on error.\n\"FailClosed\" (default) rejects the request on any failure.",
@@ -8259,7 +8532,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "requestAttributes": {
                             "additionalProperties": {
@@ -8290,13 +8564,15 @@
                             "message": "backendRef is required",
                             "rule": "has(self.backendRef)"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -8398,7 +8674,8 @@
                       "type": "string"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "requestAttributes": {
                   "additionalProperties": {
@@ -8433,7 +8710,8 @@
                   "message": "backendRef: Required value",
                   "rule": "has(self.conditional) ? true : has(self.backendRef)"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "headerModifiers": {
               "description": "Request and response header modification policy.",
@@ -8464,7 +8742,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -8505,7 +8784,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -8515,7 +8795,8 @@
                       "x-kubernetes-list-type": "map"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "response": {
                   "description": "Header changes to apply before returning a response.",
@@ -8543,7 +8824,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -8584,7 +8866,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -8594,7 +8877,8 @@
                       "x-kubernetes-list-type": "map"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -8603,7 +8887,8 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "hostRewrite": {
               "description": "How to rewrite the `Host` header for requests.\n\nIf the `HTTPRoute` `urlRewrite` filter already specifies a host rewrite,\nthis setting is ignored.",
@@ -8620,7 +8905,8 @@
               "required": [
                 "mode"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "jwtAuthentication": {
               "description": "Authenticates users based on JWT tokens.",
@@ -8639,7 +8925,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -8665,7 +8952,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "queryParameter": {
                       "properties": {
@@ -8678,7 +8966,8 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",
@@ -8687,7 +8976,8 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "mcp": {
                   "description": "Enables MCP OAuth metadata endpoint handling\nand MCP-specific authentication behavior on top of standard JWT validation.\nWhen set, the gateway will serve the MCP OAuth metadata discovery endpoints.",
@@ -8716,7 +9006,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mode": {
                   "default": "Strict",
@@ -8732,7 +9023,7 @@
                   "items": {
                     "properties": {
                       "audiences": {
-                        "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                        "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                         "items": {
                           "type": "string"
                         },
@@ -8741,7 +9032,7 @@
                         "type": "array"
                       },
                       "issuer": {
-                        "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                        "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                         "maxLength": 256,
                         "minLength": 1,
                         "type": "string"
@@ -8806,7 +9097,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "cacheDuration": {
                                 "default": "5m",
@@ -8834,7 +9126,8 @@
                               "backendRef",
                               "jwksPath"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -8843,14 +9136,16 @@
                             "message": "exactly one of the fields in [remote inline] must be set",
                             "rule": "[has(self.remote),has(self.inline)].filter(x,x==true).size() == 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "issuer",
                       "jwks"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -8870,7 +9165,8 @@
                   "message": "jwtAuthentication.mcp requires mode Strict",
                   "rule": "!has(self.mcp) || !has(self.mode) || self.mode == 'Strict'"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "phase": {
               "description": "The phase to apply the traffic policy to. If the phase is `PreRouting`,\nthe `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is\ntypically used only when a policy needs to influence the routing\ndecision.\n\nEven when using `PostRouting` mode, the policy can target the\n`Gateway` or `Listener`. This is a helper for applying the policy to all\nroutes under that `Gateway` or `Listener`, and follows the merging logic\ndescribed above.\n\nNote: `PreRouting` and `PostRouting` rules do not merge together. These\nare independent execution phases. That is, all `PreRouting` rules will\nmerge and execute, then all `PostRouting` rules will merge and execute.\n\nIf unset, this defaults to `PostRouting`.",
@@ -8947,7 +9243,8 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ]
+                                ],
+                                "additionalProperties": false
                               },
                               "descriptors": {
                                 "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
@@ -8981,7 +9278,8 @@
                                           "expression",
                                           "name"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -8999,7 +9297,8 @@
                                   "required": [
                                     "entries"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -9025,7 +9324,8 @@
                               "descriptors",
                               "domain"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "local": {
                             "description": "Local rate limiting policy.",
@@ -9068,7 +9368,8 @@
                                   "message": "exactly one of the fields in [requests tokens] must be set",
                                   "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
                                 }
-                              ]
+                              ],
+                              "additionalProperties": false
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -9081,13 +9382,15 @@
                             "message": "at least one of the fields in [global local] must be set",
                             "rule": "[has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -9150,7 +9453,8 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ]
+                      ],
+                      "additionalProperties": false
                     },
                     "descriptors": {
                       "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
@@ -9184,7 +9488,8 @@
                                 "expression",
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -9202,7 +9507,8 @@
                         "required": [
                           "entries"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9228,7 +9534,8 @@
                     "descriptors",
                     "domain"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "local": {
                   "description": "Local rate limiting policy.",
@@ -9271,7 +9578,8 @@
                         "message": "exactly one of the fields in [requests tokens] must be set",
                         "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
                       }
-                    ]
+                    ],
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -9288,7 +9596,8 @@
                   "message": "conditional cannot be set with any other field",
                   "rule": "has(self.conditional) ? [has(self.global),has(self.local)].filter(x,x==true).size() == 0 : true"
                 }
-              ]
+              ],
+              "additionalProperties": false
             },
             "retry": {
               "description": "Retry policy.",
@@ -9327,7 +9636,8 @@
                   "type": "string"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "timeouts": {
               "description": "Request timeouts.\nIt is applicable to `HTTPRoute` resources and ignored for other targeted\nkinds.",
@@ -9348,7 +9658,8 @@
                   ]
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses\nbefore forwarding them to the destination.",
@@ -9397,7 +9708,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -9473,7 +9785,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -9490,7 +9803,8 @@
                                 "message": "at least one of the fields in [add body metadata remove set] must be set",
                                 "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "response": {
                             "description": "Response transformation settings.",
@@ -9523,7 +9837,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -9599,7 +9914,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -9616,7 +9932,8 @@
                                 "message": "at least one of the fields in [add body metadata remove set] must be set",
                                 "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                               }
-                            ]
+                            ],
+                            "additionalProperties": false
                           }
                         },
                         "type": "object",
@@ -9625,13 +9942,15 @@
                             "message": "at least one of the fields in [request response] must be set",
                             "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                           }
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -9674,7 +9993,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9750,7 +10070,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9767,7 +10088,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -9800,7 +10122,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9876,7 +10199,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9893,7 +10217,8 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -9906,7 +10231,8 @@
                   "message": "conditional cannot be set with any other field",
                   "rule": "has(self.conditional) ? [has(self.request),has(self.response)].filter(x,x==true).size() == 0 : true"
                 }
-              ]
+              ],
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -9915,7 +10241,8 @@
               "message": "phase PreRouting only supports extAuth, authorization, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors",
               "rule": "has(self.phase) && self.phase == 'PreRouting' ? [has(self.buffer),has(self.csrf),has(self.delay),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size() == 0 : true"
             }
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -9988,7 +10315,8 @@
           "message": "exactly one of the fields in [targetRefs targetSelectors] must be set",
           "rule": "[has(self.targetRefs),has(self.targetSelectors)].filter(x,x==true).size() == 1"
         }
-      ]
+      ],
+      "additionalProperties": false
     },
     "status": {
       "description": "Current policy status.",
@@ -10047,7 +10375,8 @@
                 "required": [
                   "name"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "conditions": {
                 "description": "Conditions describing the status of the policy for this ancestor",
@@ -10100,7 +10429,8 @@
                     "status",
                     "type"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "maxItems": 8,
                 "minItems": 1,
@@ -10123,7 +10453,8 @@
               "conditions",
               "controllerName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "maxItems": 16,
           "type": "array",
@@ -10133,7 +10464,8 @@
       "required": [
         "ancestors"
       ],
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
+++ b/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
@@ -26,16 +26,9 @@
                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                     "properties": {
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       },
                       "value": {
@@ -47,8 +40,7 @@
                       "field",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -68,16 +60,9 @@
                     "description": "Default value for a field in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
                     "properties": {
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       },
                       "value": {
@@ -89,8 +74,7 @@
                       "field",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -117,8 +101,7 @@
                           "content",
                           "role"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -140,14 +123,12 @@
                           "content",
                           "role"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "promptCaching": {
                   "description": "Automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
@@ -175,13 +156,12 @@
                     },
                     "minTokens": {
                       "default": 1024,
-                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count \u00d7 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "description": "Minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
                       "minimum": 0,
                       "type": "integer"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "promptGuard": {
                   "description": "Guardrails for LLM requests and responses.",
@@ -204,10 +184,10 @@
                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                     "properties": {
                                       "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                         "properties": {
                                           "assumeRole": {
                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -217,27 +197,90 @@
                                                 "minLength": 1,
                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                 "type": "string"
+                                              },
+                                              "sessionName": {
+                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                "type": "string"
+                                              },
+                                              "sessionNameExpression": {
+                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                "maxLength": 16384,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "tags": {
+                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                "items": {
+                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                  "properties": {
+                                                    "expression": {
+                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                      "maxLength": 16384,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key is the tag key.",
+                                                      "maxLength": 128,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is a static tag value.",
+                                                      "maxLength": 256,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "exactly one of value or expression must be set",
+                                                      "rule": "has(self.value) != has(self.expression)"
+                                                    }
+                                                  ]
+                                                },
+                                                "maxItems": 50,
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                  "key"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
                                               }
                                             },
                                             "required": [
                                               "roleArn"
                                             ],
                                             "type": "object",
-                                            "additionalProperties": false
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                              }
+                                            ]
+                                          },
+                                          "region": {
+                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -253,8 +296,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -269,133 +311,15 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -408,13 +332,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -429,8 +352,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -443,8 +365,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -453,26 +374,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -488,28 +410,27 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                        "message": "location may only be set for key or secretRef auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                       },
                                       {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -523,7 +444,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -531,14 +452,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -556,6 +477,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -577,6 +499,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -590,15 +513,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -618,20 +539,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -652,20 +572,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -681,8 +601,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -721,25 +640,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -752,14 +670,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -775,19 +693,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -807,8 +728,7 @@
                               "region",
                               "version"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -824,135 +744,10 @@
                                 "description": "Policies for communicating with Google Model Armor.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to Google Model Armor.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
                                       "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                         "properties": {
                                           "audience": {
                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -961,18 +756,24 @@
                                             "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -988,8 +789,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -1006,130 +806,23 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                        "maxLength": 2048,
-                                        "type": "string"
-                                      },
-                                      "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                        "properties": {
-                                          "cookie": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "header": {
-                                            "properties": {
-                                              "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                "type": "string"
-                                              },
-                                              "prefix": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "queryParameter": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
-                                      },
-                                      "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                        "properties": {
-                                          "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                            "type": "string"
-                                          },
-                                          "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                            "type": "string"
-                                          },
-                                          "name": {
-                                            "description": "The name of the referenced credential.",
-                                            "maxLength": 253,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "name"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "custom credential refs must set both group and kind",
-                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [gcp] must be set",
+                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -1143,7 +836,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -1151,14 +844,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -1176,6 +869,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -1197,6 +891,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -1210,15 +905,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -1238,20 +931,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -1272,20 +964,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -1301,8 +993,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -1341,25 +1032,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -1372,14 +1062,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -1395,19 +1085,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -1426,8 +1119,7 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "openAIModeration": {
                             "description": "Passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
@@ -1440,198 +1132,15 @@
                                 "description": "Policies for communicating with OpenAI.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to OpenAI.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
                                       "key": {
                                         "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where backend credentials are inserted. Defaults to the `Authorization`\nheader with the `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -1644,13 +1153,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -1665,8 +1173,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -1679,8 +1186,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -1689,26 +1195,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -1724,28 +1231,23 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -1759,7 +1261,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -1767,14 +1269,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -1792,6 +1294,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -1813,6 +1316,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -1826,15 +1330,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -1854,20 +1356,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -1888,20 +1389,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -1917,8 +1418,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -1957,25 +1457,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -1988,14 +1487,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -2011,23 +1510,25 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -2066,8 +1567,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
@@ -2092,8 +1592,7 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "webhook": {
                             "description": "Webhook that receives requests for prompt guarding.",
@@ -2103,14 +1602,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -2123,14 +1622,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -2146,8 +1645,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -2163,7 +1661,7 @@
                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                   "properties": {
                                     "name": {
-                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                       "maxLength": 256,
                                       "minLength": 1,
                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -2171,7 +1669,7 @@
                                     },
                                     "type": {
                                       "default": "Exact",
-                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                       "enum": [
                                         "Exact",
                                         "RegularExpression"
@@ -2179,7 +1677,7 @@
                                       "type": "string"
                                     },
                                     "value": {
-                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "description": "Value of the HTTP header to match",
                                       "maxLength": 4096,
                                       "minLength": 1,
                                       "type": "string"
@@ -2189,17 +1687,26 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "CEL-computed headers to include in webhook requests.",
+                                "maxProperties": 64,
+                                "type": "object"
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -2208,8 +1715,7 @@
                             "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -2233,10 +1739,10 @@
                                 "description": "Policies for communicating with AWS Bedrock Guardrails.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to AWS Bedrock Guardrails.",
                                     "properties": {
                                       "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
+                                        "description": "AWS authentication method for Bedrock Guardrails. Use `aws: {}` for\ndefault AWS SDK credential discovery.",
                                         "properties": {
                                           "assumeRole": {
                                             "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
@@ -2246,27 +1752,90 @@
                                                 "minLength": 1,
                                                 "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                                                 "type": "string"
+                                              },
+                                              "sessionName": {
+                                                "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                                                "pattern": "^[\\w+=,.@-]{2,64}$",
+                                                "type": "string"
+                                              },
+                                              "sessionNameExpression": {
+                                                "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                                                "maxLength": 16384,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "tags": {
+                                                "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                                                "items": {
+                                                  "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                                                  "properties": {
+                                                    "expression": {
+                                                      "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                                      "maxLength": 16384,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "key": {
+                                                      "description": "Key is the tag key.",
+                                                      "maxLength": 128,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is a static tag value.",
+                                                      "maxLength": 256,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "x-kubernetes-validations": [
+                                                    {
+                                                      "message": "exactly one of value or expression must be set",
+                                                      "rule": "has(self.value) != has(self.expression)"
+                                                    }
+                                                  ]
+                                                },
+                                                "maxItems": 50,
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                  "key"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
                                               }
                                             },
                                             "required": [
                                               "roleArn"
                                             ],
                                             "type": "object",
-                                            "additionalProperties": false
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                                                "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                                              }
+                                            ]
+                                          },
+                                          "region": {
+                                            "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -2282,8 +1851,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "serviceName": {
                                             "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -2298,133 +1866,15 @@
                                             "message": "secretRef and assumeRole are mutually exclusive",
                                             "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
-                                        "properties": {
-                                          "audience": {
-                                            "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "type": {
-                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
-                                            "enum": [
-                                              "AccessToken",
-                                              "IdToken"
-                                            ],
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "audience is only valid with IdToken",
-                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "description": "Inline API key to use as the value of the `Authorization` header.\nThis option is the least secure; usage of a `Secret` is preferred.",
                                         "maxLength": 2048,
                                         "type": "string"
                                       },
                                       "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "description": "Where API keys are inserted. Defaults to the `Authorization` header with\nthe `Bearer ` prefix. Applies to `key` and `secretRef`.",
                                         "properties": {
                                           "cookie": {
                                             "properties": {
@@ -2437,13 +1887,12 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "header": {
                                             "properties": {
                                               "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                                                 "maxLength": 256,
                                                 "minLength": 1,
                                                 "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -2458,8 +1907,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "queryParameter": {
                                             "properties": {
@@ -2472,8 +1920,7 @@
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -2482,26 +1929,27 @@
                                             "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                                             "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
+                                        ]
                                       },
                                       "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                                        "description": "Credential source for the API key, defaulting to a Kubernetes `Secret`.\nBy default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                                         "properties": {
                                           "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                            "description": "API group of the referenced credential; empty selects the core API group",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                            "maxLength": 253,
+                                            "minLength": 1,
                                             "type": "string"
                                           },
                                           "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "The name of the referenced credential.",
+                                            "description": "Name of the referenced credential",
                                             "maxLength": 253,
                                             "minLength": 1,
                                             "type": "string"
@@ -2517,28 +1965,27 @@
                                             "message": "custom credential refs must set both group and kind",
                                             "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                        "message": "location may only be set for key or secretRef auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) : true"
                                       },
                                       {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [key secretRef aws] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -2552,7 +1999,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -2560,14 +2007,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -2585,6 +2032,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -2606,6 +2054,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -2619,15 +2068,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -2647,20 +2094,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -2681,20 +2127,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -2710,8 +2156,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -2750,25 +2195,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -2781,14 +2225,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -2804,19 +2248,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "region": {
                                 "description": "AWS region where the guardrail is deployed, for example\n`us-west-2`).",
@@ -2836,8 +2283,7 @@
                               "region",
                               "version"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "googleModelArmor": {
                             "description": "Google Model Armor settings for prompt guarding.",
@@ -2853,135 +2299,10 @@
                                 "description": "Policies for communicating with Google Model Armor.",
                                 "properties": {
                                   "auth": {
-                                    "description": "Settings for managing authentication to the backend.",
+                                    "description": "Settings for authenticating to Google Model Armor.",
                                     "properties": {
-                                      "aws": {
-                                        "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
-                                        "properties": {
-                                          "assumeRole": {
-                                            "description": "AWS STS AssumeRole settings to use before signing backend requests.\nAmbient AWS credentials are used as the source credentials for STS.",
-                                            "properties": {
-                                              "roleArn": {
-                                                "description": "AWS IAM role ARN to assume.",
-                                                "minLength": 1,
-                                                "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "roleArn"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          },
-                                          "serviceName": {
-                                            "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
-                                            "maxLength": 256,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "secretRef and assumeRole are mutually exclusive",
-                                            "rule": "!(has(self.secretRef) && has(self.assumeRole))"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "azure": {
-                                        "description": "Azure authentication method for the backend.",
-                                        "properties": {
-                                          "managedIdentity": {
-                                            "description": "Managed identity authentication settings.",
-                                            "properties": {
-                                              "clientId": {
-                                                "type": "string"
-                                              },
-                                              "objectId": {
-                                                "type": "string"
-                                              },
-                                              "resourceId": {
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "clientId",
-                                              "objectId",
-                                              "resourceId"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
-                                            "properties": {
-                                              "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                                "type": "string"
-                                              },
-                                              "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                                "type": "string"
-                                              },
-                                              "name": {
-                                                "description": "The name of the referenced credential.",
-                                                "maxLength": 253,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "x-kubernetes-validations": [
-                                              {
-                                                "message": "custom credential refs must set both group and kind",
-                                                "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                              }
-                                            ],
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
                                       "gcp": {
-                                        "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
+                                        "description": "Google authentication method for Model Armor. Use `gcp: {}` for default\nGoogle credential discovery.",
                                         "properties": {
                                           "audience": {
                                             "description": "Explicit `aud` value for the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
@@ -2990,18 +2311,24 @@
                                             "type": "string"
                                           },
                                           "secretRef": {
-                                            "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                                            "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                                             "properties": {
                                               "group": {
-                                                "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                                "description": "API group of the referenced credential; empty selects the core API group",
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                                "maxLength": 253,
+                                                "minLength": 1,
                                                 "type": "string"
                                               },
                                               "kind": {
-                                                "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                                "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                                 "type": "string"
                                               },
                                               "name": {
-                                                "description": "The name of the referenced credential.",
+                                                "description": "Name of the referenced credential",
                                                 "maxLength": 253,
                                                 "minLength": 1,
                                                 "type": "string"
@@ -3017,8 +2344,7 @@
                                                 "message": "custom credential refs must set both group and kind",
                                                 "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                               }
-                                            ],
-                                            "additionalProperties": false
+                                            ]
                                           },
                                           "type": {
                                             "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -3035,130 +2361,23 @@
                                             "message": "audience is only valid with IdToken",
                                             "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "key": {
-                                        "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
-                                        "maxLength": 2048,
-                                        "type": "string"
-                                      },
-                                      "location": {
-                                        "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
-                                        "properties": {
-                                          "cookie": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "header": {
-                                            "properties": {
-                                              "name": {
-                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
-                                                "type": "string"
-                                              },
-                                              "prefix": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "queryParameter": {
-                                            "properties": {
-                                              "name": {
-                                                "maxLength": 256,
-                                                "minLength": 1,
-                                                "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "name"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
-                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
-                                          }
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "passthrough": {
-                                        "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
-                                        "type": "object"
-                                      },
-                                      "secretRef": {
-                                        "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
-                                        "properties": {
-                                          "group": {
-                                            "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
-                                            "type": "string"
-                                          },
-                                          "kind": {
-                                            "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
-                                            "type": "string"
-                                          },
-                                          "name": {
-                                            "description": "The name of the referenced credential.",
-                                            "maxLength": 253,
-                                            "minLength": 1,
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": [
-                                          "name"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "x-kubernetes-validations": [
-                                          {
-                                            "message": "custom credential refs must set both group and kind",
-                                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
-                                          }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "type": "object",
                                     "x-kubernetes-validations": [
                                       {
-                                        "message": "location may only be set for key or passthrough auth",
-                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
-                                      },
-                                      {
-                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                        "message": "exactly one of the fields in [gcp] must be set",
+                                        "rule": "[has(self.gcp)].filter(x,x==true).size() == 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "http": {
-                                    "description": "Settings for managing HTTP requests to the backend.",
+                                    "description": "Settings for managing HTTP requests to the backend",
                                     "properties": {
                                       "requestTimeout": {
                                         "description": "Deadline for receiving a response from the backend.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -3172,7 +2391,7 @@
                                         ]
                                       },
                                       "version": {
-                                        "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                                         "enum": [
                                           "HTTP1",
                                           "HTTP2"
@@ -3180,14 +2399,14 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tcp": {
-                                    "description": "Settings for managing TCP connections to the backend.",
+                                    "description": "Settings for managing TCP connections to the backend",
                                     "properties": {
                                       "connectTimeout": {
                                         "description": "Deadline for establishing a connection to\nthe destination.",
+                                        "maxLength": 32,
                                         "type": "string",
                                         "x-kubernetes-validations": [
                                           {
@@ -3205,6 +2424,7 @@
                                         "properties": {
                                           "interval": {
                                             "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -3226,6 +2446,7 @@
                                           },
                                           "time": {
                                             "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "maxLength": 32,
                                             "type": "string",
                                             "x-kubernetes-validations": [
                                               {
@@ -3239,15 +2460,13 @@
                                             ]
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "tls": {
-                                    "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
                                     "properties": {
                                       "alpnProtocols": {
                                         "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -3267,20 +2486,19 @@
                                           "properties": {
                                             "name": {
                                               "default": "",
-                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "description": "Name of the referent",
                                               "type": "string"
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "maxItems": 1,
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "insecureSkipVerify": {
-                                        "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                                         "enum": [
                                           "All",
                                           "Hostname"
@@ -3301,20 +2519,20 @@
                                         "type": "array"
                                       },
                                       "mtlsCertificateRef": {
-                                        "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                                         "items": {
-                                          "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                                          "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                                           "properties": {
                                             "group": {
-                                              "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                                              "description": "API group of the referenced credential; empty selects the core API group",
                                               "type": "string"
                                             },
                                             "kind": {
-                                              "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
                                               "type": "string"
                                             },
                                             "name": {
-                                              "description": "The name of the referenced credential.",
+                                              "description": "Name of the referenced credential",
                                               "maxLength": 253,
                                               "minLength": 1,
                                               "type": "string"
@@ -3330,8 +2548,7 @@
                                               "message": "custom credential refs must set both group and kind",
                                               "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                                             }
-                                          ],
-                                          "additionalProperties": false
+                                          ]
                                         },
                                         "maxItems": 1,
                                         "type": "array",
@@ -3370,25 +2587,24 @@
                                         "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                                         "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                                       }
-                                    ],
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "tunnel": {
-                                    "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+                                    "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
                                     "properties": {
                                       "backendRef": {
                                         "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                                         "properties": {
                                           "group": {
                                             "default": "",
-                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                             "maxLength": 253,
                                             "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                             "type": "string"
                                           },
                                           "kind": {
                                             "default": "Service",
-                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -3401,14 +2617,14 @@
                                             "type": "string"
                                           },
                                           "namespace": {
-                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                             "maxLength": 63,
                                             "minLength": 1,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "type": "string"
                                           },
                                           "port": {
-                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                             "format": "int32",
                                             "maximum": 65535,
                                             "minimum": 1,
@@ -3424,19 +2640,22 @@
                                             "message": "Must have port for Service reference",
                                             "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                           }
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
                                     },
                                     "required": [
                                       "backendRef"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
-                                "additionalProperties": false
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "at least one of the fields in [auth http tcp tls tunnel] must be set",
+                                    "rule": "[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                                  }
+                                ]
                               },
                               "projectId": {
                                 "description": "Google Cloud project ID.",
@@ -3455,8 +2674,7 @@
                               "projectId",
                               "templateId"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "regex": {
                             "description": "Regular expression (regex) matching for prompt guards and data masking.",
@@ -3495,8 +2713,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "response": {
                             "description": "Custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
@@ -3521,8 +2738,7 @@
                                 "message": "at least one of the fields in [message statusCode] must be set",
                                 "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "webhook": {
                             "description": "Webhook that receives responses for prompt guarding.",
@@ -3532,14 +2748,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -3552,14 +2768,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -3575,8 +2791,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "failureMode": {
                                 "description": "Behavior when the webhook guardrail is unavailable\nor returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) rejects the request.",
@@ -3592,7 +2807,7 @@
                                   "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
                                   "properties": {
                                     "name": {
-                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "description": "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
                                       "maxLength": 256,
                                       "minLength": 1,
                                       "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -3600,7 +2815,7 @@
                                     },
                                     "type": {
                                       "default": "Exact",
-                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "description": "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
                                       "enum": [
                                         "Exact",
                                         "RegularExpression"
@@ -3608,7 +2823,7 @@
                                       "type": "string"
                                     },
                                     "value": {
-                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "description": "Value of the HTTP header to match",
                                       "maxLength": 4096,
                                       "minLength": 1,
                                       "type": "string"
@@ -3618,17 +2833,26 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "description": "A Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "CEL-computed headers to include in webhook requests.",
+                                "maxProperties": 64,
+                                "type": "object"
                               }
                             },
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -3637,8 +2861,7 @@
                             "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
                             "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 8,
                       "minItems": 1,
@@ -3658,8 +2881,7 @@
                       "message": "at least one of the fields in [request response] must be set",
                       "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "routes": {
                   "additionalProperties": {
@@ -3693,16 +2915,9 @@
                         "type": "string"
                       },
                       "field": {
-                        "allOf": [
-                          {
-                            "minLength": 1
-                          },
-                          {
-                            "minLength": 1
-                          }
-                        ],
                         "description": "Name of the field to set.",
                         "maxLength": 256,
+                        "minLength": 1,
                         "type": "string"
                       }
                     },
@@ -3710,8 +2925,7 @@
                       "expression",
                       "field"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -3724,11 +2938,10 @@
                   "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
                   "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "auth": {
-              "description": "Settings for managing authentication to the backend.",
+              "description": "Settings for managing authentication to the backend",
               "properties": {
                 "aws": {
                   "description": "Explicit AWS authentication method for the backend.\nWhen omitted, default AWS SDK credential discovery is used.",
@@ -3741,27 +2954,90 @@
                           "minLength": 1,
                           "pattern": "^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$",
                           "type": "string"
+                        },
+                        "sessionName": {
+                          "description": "SessionName is a custom session name (RoleSessionName) for CloudTrail and\nCost & Usage Report attribution. If unset, AWS generates a random name.",
+                          "pattern": "^[\\w+=,.@-]{2,64}$",
+                          "type": "string"
+                        },
+                        "sessionNameExpression": {
+                          "description": "SessionNameExpression is a CEL expression evaluated against each request\nto produce the session name (RoleSessionName), for example `jwt.sub` or\n`request.headers[\"x-team\"]`. If the expression does not produce a valid\nsession name at request time, the request is rejected.",
+                          "maxLength": 16384,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tags": {
+                          "description": "Session tags passed to STS AssumeRole for cost attribution in the AWS Cost\n& Usage Report, once activated. STS allows at most 50 per role session.",
+                          "items": {
+                            "description": "AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost\nattribution. Exactly one of value and expression must be set.",
+                            "properties": {
+                              "expression": {
+                                "description": "CEL expression evaluated against each request to produce the tag value,\nfor example `jwt.sub` or `request.headers[\"x-app\"]`. Requests with invalid\ntag values are rejected.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the tag key.",
+                                "maxLength": 128,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is a static tag value.",
+                                "maxLength": 256,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "exactly one of value or expression must be set",
+                                "rule": "has(self.value) != has(self.expression)"
+                              }
+                            ]
+                          },
+                          "maxItems": 50,
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "key"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         }
                       },
                       "required": [
                         "roleArn"
                       ],
                       "type": "object",
-                      "additionalProperties": false
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "at most one of the fields in [sessionName sessionNameExpression] may be set",
+                          "rule": "[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size() <= 1"
+                        }
+                      ]
+                    },
+                    "region": {
+                      "description": "AWS SigV4 signing region, for example `us-east-1`. Set this when the\ntarget AWS service is in a different region than the gateway. If unset,\ntyped AWS backends may provide this automatically; otherwise the ambient\nAWS region is used.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the AWS credentials. When using the default Secret\nresolver, the `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "description": "Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.\nThe default Secret resolver expects `accessKey`, `secretKey`, and optional\n`sessionToken` keys.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -3777,8 +3053,7 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "serviceName": {
                       "description": "AWS SigV4 signing service name, for example\n`bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS\nbackends may provide this automatically.",
@@ -3793,8 +3068,7 @@
                       "message": "secretRef and assumeRole are mutually exclusive",
                       "rule": "!(has(self.secretRef) && has(self.assumeRole))"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "azure": {
                   "description": "Azure authentication method for the backend.",
@@ -3817,22 +3091,21 @@
                         "objectId",
                         "resourceId"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing the Azure credentials. When using the default Secret\nresolver, the `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "description": "Credential source for Azure credentials, defaulting to a Kubernetes\n`Secret`. The default Secret resolver expects `clientID`, `tenantID`, and\n`clientSecret` keys.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -3848,12 +3121,766 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
+                    },
+                    "workloadIdentity": {
+                      "description": "Workload identity authentication settings. Uses the federated token and\nAzure env vars projected into the data plane pod. Recommended on AKS with\nWorkload Identity enabled.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
-                  "additionalProperties": false
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at most one of the fields in [secretRef managedIdentity workloadIdentity] may be set",
+                      "rule": "[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size() <= 1"
+                    }
+                  ]
+                },
+                "credentials": {
+                  "description": "Credentials is a list of additional credentials to inject on the\nbackend request. Each entry resolves a Secret key and writes its value\nto the entry's location. `credentials` is independent of the primary\n`key`/`secretRef`/`passthrough` mechanism and may be set on its own or\nalongside it.",
+                  "items": {
+                    "description": "BackendAuthCredential specifies one additional credential to inject on the\nbackend request.",
+                    "properties": {
+                      "location": {
+                        "description": "Where the credential is inserted on the backend request.",
+                        "properties": {
+                          "cookie": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "header": {
+                            "properties": {
+                              "name": {
+                                "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                "type": "string"
+                              },
+                              "prefix": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "queryParameter": {
+                            "properties": {
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references a Kubernetes Secret holding the credential value, and\noptionally overrides the key read from it. Defaults to `Authorization`,\nmatching the key convention used by the top-level `secretRef`.",
+                        "properties": {
+                          "group": {
+                            "description": "API group of the referenced credential; empty selects the core API group",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referenced credential",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "custom credential refs must set both group and kind",
+                            "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "location",
+                      "secretRef"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 8,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "crossAppAccess": {
+                  "description": "Cross App Access (Identity Assertion / ID-JAG) authentication.",
+                  "properties": {
+                    "audience": {
+                      "description": "Identifier of the resource authorization server. The issued ID-JAG is bound to this audience.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "cache": {
+                      "description": "Response cache configuration.",
+                      "properties": {
+                        "inMemory": {
+                          "properties": {
+                            "defaultTtl": {
+                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                              "type": "string"
+                            },
+                            "maxEntries": {
+                              "description": "Default 8192; 0 disables the cache.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "identityProvider": {
+                      "description": "User identity provider authorization server, used for the RFC 8693 ID-JAG exchange.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Token endpoint backend.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "clientAuth": {
+                          "description": "Client authentication for the token endpoint.",
+                          "properties": {
+                            "clientId": {
+                              "description": "Client ID sent to the token endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "method": {
+                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                              "enum": [
+                                "ClientSecretBasic",
+                                "ClientSecretPost",
+                                "PrivateKeyJwt"
+                              ],
+                              "type": "string"
+                            },
+                            "privateKeyJwt": {
+                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                              "properties": {
+                                "alg": {
+                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                  "enum": [
+                                    "ES256",
+                                    "ES384",
+                                    "PS256",
+                                    "RS256",
+                                    "RS384",
+                                    "RS512"
+                                  ],
+                                  "type": "string"
+                                },
+                                "assertionAudience": {
+                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "certificateHeader": {
+                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                  "enum": [
+                                    "x5c",
+                                    "x5t#S256"
+                                  ],
+                                  "type": "string"
+                                },
+                                "certificateRef": {
+                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                },
+                                "kid": {
+                                  "description": "Optional JWS key ID header.",
+                                  "type": "string"
+                                },
+                                "signingKeyRef": {
+                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assertionAudience",
+                                "signingKeyRef"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "certificateRef and certificateHeader must be set together",
+                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                }
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "clientId"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                            },
+                            {
+                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                            },
+                            {
+                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                            }
+                          ]
+                        },
+                        "path": {
+                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                          "pattern": "^/",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "clientAuth"
+                      ],
+                      "type": "object"
+                    },
+                    "resourceAuthorizationServer": {
+                      "description": "Resource authorization server, used for the RFC 7523 jwt-bearer exchange.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "Token endpoint backend.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "clientAuth": {
+                          "description": "Client authentication for the token endpoint.",
+                          "properties": {
+                            "clientId": {
+                              "description": "Client ID sent to the token endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "method": {
+                              "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                              "enum": [
+                                "ClientSecretBasic",
+                                "ClientSecretPost",
+                                "PrivateKeyJwt"
+                              ],
+                              "type": "string"
+                            },
+                            "privateKeyJwt": {
+                              "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                              "properties": {
+                                "alg": {
+                                  "description": "JWS signing algorithm. Defaults to RS256.",
+                                  "enum": [
+                                    "ES256",
+                                    "ES384",
+                                    "PS256",
+                                    "RS256",
+                                    "RS384",
+                                    "RS512"
+                                  ],
+                                  "type": "string"
+                                },
+                                "assertionAudience": {
+                                  "description": "Audience for the client assertion, typically the token endpoint URL.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "certificateHeader": {
+                                  "description": "JWS certificate header. Required when certificateRef is set.",
+                                  "enum": [
+                                    "x5c",
+                                    "x5t#S256"
+                                  ],
+                                  "type": "string"
+                                },
+                                "certificateRef": {
+                                  "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                },
+                                "kid": {
+                                  "description": "Optional JWS key ID header.",
+                                  "type": "string"
+                                },
+                                "signingKeyRef": {
+                                  "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                                  "properties": {
+                                    "group": {
+                                      "description": "API group of the referenced credential; empty selects the core API group",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referenced credential",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "custom credential refs must set both group and kind",
+                                      "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "assertionAudience",
+                                "signingKeyRef"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "certificateRef and certificateHeader must be set together",
+                                  "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                                }
+                              ]
+                            },
+                            "secretRef": {
+                              "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "clientId"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                              "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                            },
+                            {
+                              "message": "secretRef is not valid with method PrivateKeyJwt",
+                              "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                            },
+                            {
+                              "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                              "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                            }
+                          ]
+                        },
+                        "path": {
+                          "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                          "pattern": "^/",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "clientAuth"
+                      ],
+                      "type": "object"
+                    },
+                    "resources": {
+                      "description": "Resources sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "description": "Scopes sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "subjectToken": {
+                      "description": "Subject token sent to the identity provider. Defaults to an OpenID Connect\nID token read from the Authorization Bearer header.",
+                      "properties": {
+                        "source": {
+                          "description": "Where to read the subject token. Defaults to the Authorization Bearer header.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "audience",
+                    "identityProvider",
+                    "resourceAuthorizationServer"
+                  ],
+                  "type": "object"
                 },
                 "gcp": {
                   "description": "Google authentication method for the backend.\nWhen omitted, default Google credential discovery is used.",
@@ -3865,18 +3892,24 @@
                       "type": "string"
                     },
                     "secretRef": {
-                      "description": "Credential source, defaulting to a Kubernetes\n`Secret`, containing ADC-compatible Google credential JSON. When using\nthe default Secret resolver, this must be stored in the `credentials.json`\nkey. When omitted, ambient credentials are used.",
+                      "description": "Credential source for ADC-compatible Google credential JSON, defaulting to\na Kubernetes `Secret`. By default, the value is read from\n`credentials.json`; set `secretRef.key` to override it. When omitted,\nambient credentials are used.",
                       "properties": {
                         "group": {
-                          "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                          "maxLength": 253,
+                          "minLength": 1,
                           "type": "string"
                         },
                         "kind": {
-                          "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
                           "type": "string"
                         },
                         "name": {
-                          "description": "The name of the referenced credential.",
+                          "description": "Name of the referenced credential",
                           "maxLength": 253,
                           "minLength": 1,
                           "type": "string"
@@ -3892,8 +3925,7 @@
                           "message": "custom credential refs must set both group and kind",
                           "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "type": {
                       "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
@@ -3910,8 +3942,7 @@
                       "message": "audience is only valid with IdToken",
                       "rule": "has(self.audience) ? self.type == 'IdToken' : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "key": {
                   "description": "Inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
@@ -3919,7 +3950,7 @@
                   "type": "string"
                 },
                 "location": {
-                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "description": "Where backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.",
                   "properties": {
                     "cookie": {
                       "properties": {
@@ -3932,13 +3963,12 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "header": {
                       "properties": {
                         "name": {
-                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                           "maxLength": 256,
                           "minLength": 1,
                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -3953,8 +3983,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "queryParameter": {
                       "properties": {
@@ -3967,8 +3996,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -3977,26 +4005,599 @@
                       "message": "exactly one of the fields in [header queryParameter cookie] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
                     }
+                  ]
+                },
+                "oauthTokenExchange": {
+                  "description": "OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523) authentication.",
+                  "properties": {
+                    "actorToken": {
+                      "description": "RFC 8693 delegation actor token. TokenExchange grant only.",
+                      "properties": {
+                        "mayAct": {
+                          "description": "may_act claim validation mode. When omitted, may_act is not enforced.",
+                          "enum": [
+                            "Required"
+                          ],
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Where to read the actor token. Actor tokens have no default source.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for actor tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "mayAct Required requires tokenType Jwt",
+                          "rule": "!has(self.mayAct) || self.mayAct != 'Required' || (has(self.tokenType) && self.tokenType == 'Jwt')"
+                        }
+                      ]
+                    },
+                    "additionalParams": {
+                      "additionalProperties": {
+                        "description": "A Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "Extra form params; values are CEL expressions over the incoming request.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "audiences": {
+                      "description": "Audiences sent to the token endpoint.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "backendRef": {
+                      "description": "RFC 8693 token endpoint backend.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ]
+                    },
+                    "cache": {
+                      "description": "Response cache configuration.",
+                      "properties": {
+                        "inMemory": {
+                          "properties": {
+                            "defaultTtl": {
+                              "description": "TTL used when the token endpoint omits expires_in. Default 300s.",
+                              "type": "string"
+                            },
+                            "maxEntries": {
+                              "description": "Default 8192; 0 disables the cache.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "clientAuth": {
+                      "description": "Client authentication for the token endpoint. When unset, none is sent.",
+                      "properties": {
+                        "clientId": {
+                          "description": "Client ID sent to the token endpoint.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "method": {
+                          "description": "Client authentication method. Defaults to ClientSecretBasic.",
+                          "enum": [
+                            "ClientSecretBasic",
+                            "ClientSecretPost",
+                            "PrivateKeyJwt"
+                          ],
+                          "type": "string"
+                        },
+                        "privateKeyJwt": {
+                          "description": "Client assertion settings. Required when method is PrivateKeyJwt.",
+                          "properties": {
+                            "alg": {
+                              "description": "JWS signing algorithm. Defaults to RS256.",
+                              "enum": [
+                                "ES256",
+                                "ES384",
+                                "PS256",
+                                "RS256",
+                                "RS384",
+                                "RS512"
+                              ],
+                              "type": "string"
+                            },
+                            "assertionAudience": {
+                              "description": "Audience for the client assertion, typically the token endpoint URL.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "certificateHeader": {
+                              "description": "JWS certificate header. Required when certificateRef is set.",
+                              "enum": [
+                                "x5c",
+                                "x5t#S256"
+                              ],
+                              "type": "string"
+                            },
+                            "certificateRef": {
+                              "description": "PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The\nleaf public key should match signingKeyRef; a mismatch only logs a warning\nbut the token endpoint will reject the assertions. Required when\ncertificateHeader is set. The key defaults to `certificate`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            },
+                            "kid": {
+                              "description": "Optional JWS key ID header.",
+                              "type": "string"
+                            },
+                            "signingKeyRef": {
+                              "description": "PEM-encoded RSA or EC private key; key defaults to `signingKey`.",
+                              "properties": {
+                                "group": {
+                                  "description": "API group of the referenced credential; empty selects the core API group",
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referenced credential",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "custom credential refs must set both group and kind",
+                                  "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "assertionAudience",
+                            "signingKeyRef"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "certificateRef and certificateHeader must be set together",
+                              "rule": "has(self.certificateRef) == has(self.certificateHeader)"
+                            }
+                          ]
+                        },
+                        "secretRef": {
+                          "description": "Secret providing the `clientSecret` key by default; override via\n`secretRef.key`. When omitted, client_id is sent without a secret, which\nis only valid with ClientSecretPost.",
+                          "properties": {
+                            "group": {
+                              "description": "API group of the referenced credential; empty selects the core API group",
+                              "type": "string"
+                            },
+                            "key": {
+                              "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the referenced credential",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "custom credential refs must set both group and kind",
+                              "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "clientId"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "privateKeyJwt settings require method PrivateKeyJwt",
+                          "rule": "has(self.privateKeyJwt) == (has(self.method) && self.method == 'PrivateKeyJwt')"
+                        },
+                        {
+                          "message": "secretRef is not valid with method PrivateKeyJwt",
+                          "rule": "!has(self.secretRef) || !has(self.method) || self.method != 'PrivateKeyJwt'"
+                        },
+                        {
+                          "message": "clientAuth without secretRef requires method ClientSecretPost or PrivateKeyJwt",
+                          "rule": "has(self.secretRef) || has(self.privateKeyJwt) || (has(self.method) && self.method == 'ClientSecretPost')"
+                        }
+                      ]
+                    },
+                    "grantType": {
+                      "description": "RFC followed by the request. Defaults to TokenExchange (RFC 8693).",
+                      "enum": [
+                        "JwtBearer",
+                        "TokenExchange"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "description": "Where the exchanged token is written to the backend request.\nDefaults to Authorization: Bearer.",
+                      "properties": {
+                        "cookie": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "header": {
+                          "properties": {
+                            "name": {
+                              "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                              "type": "string"
+                            },
+                            "prefix": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "queryParameter": {
+                          "properties": {
+                            "name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                          "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                        }
+                      ]
+                    },
+                    "path": {
+                      "description": "Token endpoint path; defaults to \"/\". Must start with \"/\".",
+                      "pattern": "^/",
+                      "type": "string"
+                    },
+                    "requestedTokenType": {
+                      "description": "RFC 8693 requested_token_type. Unlike subject/actor token types, only the\nbuilt-in values may be requested; custom URIs are not supported here.",
+                      "enum": [
+                        "AccessToken",
+                        "Jwt",
+                        "IdToken",
+                        "IdJag"
+                      ],
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "Resources sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "scopes": {
+                      "description": "Scopes sent to the token endpoint.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "subjectToken": {
+                      "description": "Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.\nThe token type may be a built-in value or a custom absolute URI for providers\nthat support custom token exchange profiles.",
+                      "properties": {
+                        "source": {
+                          "description": "Where to read the token. CEL `expression` variant is permitted.",
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "expression": {
+                              "description": "CEL expression that extracts the credential from the request.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "header": {
+                              "properties": {
+                                "name": {
+                                  "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "queryParameter": {
+                              "properties": {
+                                "name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
+                              "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
+                            }
+                          ]
+                        },
+                        "tokenType": {
+                          "description": "OAuth token type. Empty defaults to AccessToken. Custom absolute URI values\nare supported for subject tokens.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "backendRef"
                   ],
-                  "additionalProperties": false
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "actorToken is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.actorToken) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType is only valid with TokenExchange grantType",
+                      "rule": "!(has(self.requestedTokenType) && has(self.grantType) && self.grantType == 'JwtBearer')"
+                    },
+                    {
+                      "message": "requestedTokenType IdJag is only supported by crossAppAccess",
+                      "rule": "!has(self.requestedTokenType) || self.requestedTokenType != 'IdJag'"
+                    }
+                  ]
                 },
                 "passthrough": {
-                  "description": "Passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "description": "Reuses a client token already validated by another policy. Those policies\nmay strip client credentials; passthrough adds the original token back to\nthe backend request. Without client auth policies, this has no effect.",
                   "type": "object"
                 },
                 "secretRef": {
-                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the key to use as the authorization value. When using\nthe default Secret resolver, this must be stored in the `Authorization`\nkey.",
+                  "description": "Credential source for the authorization value, defaulting to a Kubernetes\n`Secret`. By default, the value is read from the `Authorization` key; set\n`secretRef.key` to override it. A `Bearer ` prefix is stripped only from\nthe default `Authorization` key.",
                   "properties": {
                     "group": {
-                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "description": "API group of the referenced credential; empty selects the core API group",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                      "maxLength": 253,
+                      "minLength": 1,
                       "type": "string"
                     },
                     "kind": {
-                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                       "type": "string"
                     },
                     "name": {
-                      "description": "The name of the referenced credential.",
+                      "description": "Name of the referenced credential",
                       "maxLength": 253,
                       "minLength": 1,
                       "type": "string"
@@ -4012,22 +4613,24 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
-                  "message": "location may only be set for key or passthrough auth",
+                  "message": "must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess (credentials may be combined with a primary auth kind)",
+                  "rule": "has(self.credentials) || has(self.key) || has(self.secretRef) || has(self.passthrough) || has(self.aws) || has(self.azure) || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)"
+                },
+                {
+                  "message": "location may only be set for key, secretRef, or passthrough auth",
                   "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
                 },
                 {
-                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
-                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                  "message": "at most one of the fields in [key secretRef passthrough aws azure gcp oauthTokenExchange crossAppAccess] may be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size() <= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "extAuth": {
               "description": "External authentication configuration for requests\nsent to this backend.",
@@ -4037,14 +4640,14 @@
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -4057,14 +4660,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -4080,11 +4683,10 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "cache": {
-                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
                   "properties": {
                     "key": {
                       "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
@@ -4115,8 +4717,7 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "failureMode": {
                   "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -4154,8 +4755,7 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -4180,8 +4780,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -4217,6 +4816,12 @@
                       "maxItems": 64,
                       "type": "array"
                     },
+                    "body": {
+                      "description": "Body is a CEL expression that produces the HTTP authorization request body.\nStrings and bytes are used directly; other values are JSON-encoded.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
                     "path": {
                       "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
                       "maxLength": 16384,
@@ -4241,18 +4846,16 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
-                  "message": "cache requires grpc",
-                  "rule": "!has(self.cache) || has(self.grpc)"
+                  "message": "forwardBody cannot be used with http.body",
+                  "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "health": {
               "description": "Settings for passive and active health checking.",
@@ -4269,6 +4872,7 @@
                     "duration": {
                       "default": "3s",
                       "description": "Base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -4282,7 +4886,7 @@
                       ]
                     },
                     "healthThreshold": {
-                      "description": "EWMA health score threshold, expressed as 0 to 100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "description": "EWMA health score threshold, from 0 to 100. When set, a backend is evicted\nonly if its computed health drops below this value after an unhealthy\nresponse (e.g. 50 evicts when EWMA health falls below 50%). Unlike\nconsecutiveFailures, this sliding-window average lets a single success delay\neviction. If both are set, either condition evicts; if neither, a single\nunhealthy response evicts.",
                       "format": "int32",
                       "maximum": 100,
                       "minimum": 0,
@@ -4296,8 +4900,7 @@
                       "type": "integer"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "unhealthyCondition": {
                   "description": "CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
@@ -4306,14 +4909,14 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "http": {
-              "description": "Settings for managing HTTP requests to the backend.",
+              "description": "Settings for managing HTTP requests to the backend",
               "properties": {
                 "requestTimeout": {
                   "description": "Deadline for receiving a response from the backend.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -4327,7 +4930,7 @@
                   ]
                 },
                 "version": {
-                  "description": "HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "description": "HTTP protocol version for backend connections. If unset, it is inferred:\n`Service` appProtocol, `HTTP2` for gRPC, the original protocol for\nplaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS\nto HTTP/2 even when the backend does not support it.",
                   "enum": [
                     "HTTP1",
                     "HTTP2"
@@ -4335,8 +4938,7 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "mcp": {
               "description": "Settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
@@ -4345,7 +4947,7 @@
                   "description": "MCP backend-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
                   "properties": {
                     "audiences": {
-                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                       "items": {
                         "type": "string"
                       },
@@ -4357,8 +4959,44 @@
                       "description": "Client ID to use for short-circuiting Dynamic Client Registration.\nIf set, the gateway will not proxy registration requests to the IDP and instead return this client ID.",
                       "type": "string"
                     },
+                    "clientSecretRef": {
+                      "description": "Reference to a Kubernetes Secret holding the OAuth client secret of the app\nregistration identified by `clientId` (for example Entra ID confidential clients,\nwhich require the secret at the token endpoint). The gateway injects it into the\ntoken requests it proxies to the provider. Defaults to the `clientSecret` key;\noverride via `clientSecretRef.key`.",
+                      "properties": {
+                        "group": {
+                          "description": "API group of the referenced credential; empty selects the core API group",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referenced credential; empty defaults to `Secret`",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referenced credential",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "custom credential refs must set both group and kind",
+                          "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
+                        }
+                      ]
+                    },
                     "issuer": {
-                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                       "maxLength": 256,
                       "minLength": 1,
                       "type": "string"
@@ -4371,14 +5009,14 @@
                           "properties": {
                             "group": {
                               "default": "",
-                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                               "maxLength": 253,
                               "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                               "type": "string"
                             },
                             "kind": {
                               "default": "Service",
-                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                               "maxLength": 63,
                               "minLength": 1,
                               "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -4391,14 +5029,14 @@
                               "type": "string"
                             },
                             "namespace": {
-                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                               "maxLength": 63,
                               "minLength": 1,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "type": "string"
                             },
                             "port": {
-                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                               "format": "int32",
                               "maximum": 65535,
                               "minimum": 1,
@@ -4414,11 +5052,11 @@
                               "message": "Must have port for Service reference",
                               "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                             }
-                          ],
-                          "additionalProperties": false
+                          ]
                         },
                         "cacheDuration": {
                           "default": "5m",
+                          "maxLength": 32,
                           "type": "string",
                           "x-kubernetes-validations": [
                             {
@@ -4442,8 +5080,7 @@
                         "backendRef",
                         "jwksPath"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "mode": {
                       "default": "Strict",
@@ -4459,6 +5096,9 @@
                       "description": "Identity provider to use for authentication.",
                       "enum": [
                         "Auth0",
+                        "Authentik",
+                        "Descope",
+                        "Entra",
                         "Keycloak",
                         "Okta"
                       ],
@@ -4475,8 +5115,7 @@
                   "required": [
                     "jwks"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "authorization": {
                   "description": "MCP backend authorization. Unlike authorization at the HTTP level, which rejects\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
@@ -4492,7 +5131,7 @@
                       "type": "string"
                     },
                     "policy": {
-                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                      "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\n`Deny` is not recommended because expression failures fail to deny; prefer\n`Allow` or `Require`. If used, design expressions defensively against evaluation errors.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
                       "properties": {
                         "matchExpressions": {
                           "description": "CEL expressions that must all evaluate to true for the rule to match.",
@@ -4510,15 +5149,13 @@
                       "required": [
                         "matchExpressions"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
                     "policy"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "guardrails": {
                   "description": "`guardrails` routes selected JSON-RPC methods through a remote policy server.",
@@ -4577,14 +5214,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -4597,14 +5234,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -4620,8 +5257,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "disallowedRequestHeaders": {
                                 "description": "`disallowedRequestHeaders` lists header names never forwarded to the\npolicy server, even if listed in `allowedRequestHeaders`. Matching is\ncase-insensitive.",
@@ -4665,8 +5301,7 @@
                             "required": [
                               "backendRef"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
@@ -4678,8 +5313,7 @@
                             "message": "exactly one of the fields in [remote] must be set",
                             "rule": "[has(self.remote)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -4689,8 +5323,7 @@
                   "required": [
                     "processors"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -4699,14 +5332,14 @@
                   "message": "at least one of the fields in [authentication authorization guardrails] must be set",
                   "rule": "[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tcp": {
-              "description": "Settings for managing TCP connections to the backend.",
+              "description": "Settings for managing TCP connections to the backend",
               "properties": {
                 "connectTimeout": {
                   "description": "Deadline for establishing a connection to\nthe destination.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -4724,6 +5357,7 @@
                   "properties": {
                     "interval": {
                       "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -4745,6 +5379,7 @@
                     },
                     "time": {
                       "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -4758,15 +5393,13 @@
                       ]
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "tls": {
-              "description": "Settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "description": "Settings for managing TLS connections to the backend\n\nWhen set, TLS is originated to the backend using the system trusted CA\ncertificates, and SNI is inferred from the destination.",
               "properties": {
                 "alpnProtocols": {
                   "description": "Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
@@ -4786,20 +5419,19 @@
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "description": "Name of the referent",
                         "type": "string"
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "maxItems": 1,
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
                 },
                 "insecureSkipVerify": {
-                  "description": "Originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "description": "Originates TLS but skips verification of the backend's certificate\nWARNING: insecure; only use if the risks are understood\n\nModes:\n* `All` disables all TLS verification\n* `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.\n  Still insecure; prefer `verifySubjectAltNames` where possible.",
                   "enum": [
                     "All",
                     "Hostname"
@@ -4820,20 +5452,20 @@
                   "type": "array"
                 },
                 "mtlsCertificateRef": {
-                  "description": "Enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\ncredential source, defaulting to a Kubernetes `Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "description": "Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the\nreferenced credential source (defaulting to a Kubernetes `Secret`). An\noptional `ca.cert`, if present, verifies the server certificate, but\n`caCertificateRefs` takes priority. If unspecified, no client certificate\nis used.",
                   "items": {
-                    "description": "References a same-namespace credential.\nSet only `name` to reference a Kubernetes Secret.",
+                    "description": "References a same-namespace credential\nSet only `name` for a Kubernetes Secret",
                     "properties": {
                       "group": {
-                        "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                        "description": "API group of the referenced credential; empty selects the core API group",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                        "description": "Kind of the referenced credential; empty defaults to `Secret`",
                         "type": "string"
                       },
                       "name": {
-                        "description": "The name of the referenced credential.",
+                        "description": "Name of the referenced credential",
                         "maxLength": 253,
                         "minLength": 1,
                         "type": "string"
@@ -4849,8 +5481,7 @@
                         "message": "custom credential refs must set both group and kind",
                         "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                       }
-                    ],
-                    "additionalProperties": false
+                    ]
                   },
                   "maxItems": 1,
                   "type": "array",
@@ -4889,8 +5520,7 @@
                   "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
                   "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses sent to and from the backend.",
@@ -4926,8 +5556,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5003,8 +5632,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5021,8 +5649,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -5055,8 +5682,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5132,8 +5758,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5150,8 +5775,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "type": "object",
@@ -5160,25 +5784,24 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tunnel": {
-              "description": "Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.",
+              "description": "Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`",
               "properties": {
                 "backendRef": {
                   "description": "Proxy server to reach.\nSupported types: `Service` and `Backend`.",
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -5191,14 +5814,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -5214,15 +5837,13 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "required": [
                 "backendRef"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
           "type": "object",
@@ -5231,8 +5852,7 @@
               "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
               "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "frontend": {
           "description": "Settings for how to handle incoming traffic.\n\nA frontend policy can only target a `Gateway`. `Listener` and\n`ListenerSet` are not valid targets.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. For example, policy A sets `tcp` and `tls`, and policy B sets\n`tls`; the effective policy would be `tcp` from policy A, and `tls` from\npolicy B.",
@@ -5263,8 +5883,7 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "minItems": 1,
                       "type": "array"
@@ -5287,8 +5906,7 @@
                       "message": "at least one of the fields in [add remove] must be set",
                       "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "filter": {
                   "description": "CEL expression used to filter logs. A log\nwill only be emitted if the expression evaluates to `true`.",
@@ -5299,19 +5917,67 @@
                 "otlp": {
                   "description": "OTLP access log export to an\nOpenTelemetry-compatible backend.",
                   "properties": {
+                    "attributes": {
+                      "description": "Customizations to the key-value pairs exported over OTLP.\nIf unset, the parent access log attributes are used.",
+                      "properties": {
+                        "add": {
+                          "description": "Additional key-value pairs to add to each entry.\nThe value is a CEL expression. If the CEL expression fails to evaluate,\nthe pair will be excluded.",
+                          "items": {
+                            "properties": {
+                              "expression": {
+                                "description": "A Common Expression Language (CEL) expression.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "name": {
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "expression",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "remove": {
+                          "description": "Default fields to remove. For example,\n`http.method`.",
+                          "items": {
+                            "maxLength": 64,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "maxItems": 32,
+                          "minItems": 1,
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "at least one of the fields in [add remove] must be set",
+                          "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                        }
+                      ]
+                    },
                     "backendRef": {
                       "description": "OTLP server to send access logs to.\nSupported types: `Service` and `AgentgatewayBackend`.",
                       "properties": {
                         "group": {
                           "default": "",
-                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                           "maxLength": 253,
                           "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                           "type": "string"
                         },
                         "kind": {
                           "default": "Service",
-                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                           "maxLength": 63,
                           "minLength": 1,
                           "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -5324,14 +5990,14 @@
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                           "maxLength": 63,
                           "minLength": 1,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "type": "string"
                         },
                         "port": {
-                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                           "format": "int32",
                           "maximum": 65535,
                           "minimum": 1,
@@ -5347,8 +6013,13 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
+                    },
+                    "filter": {
+                      "description": "CEL expression used to filter OTLP logs. A log\nwill only be exported if the expression evaluates to `true`.\nIf unset, the parent access log filter is used.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
                     },
                     "path": {
                       "description": "OTLP/HTTP path to use. This is only applicable\nwhen `protocol` is `HTTP`. If unset, this defaults to `/v1/logs`.",
@@ -5379,12 +6050,10 @@
                       "message": "path must start with /",
                       "rule": "!has(self.path) || self.path.startsWith('/')"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "connect": {
               "description": "Settings for downstream HTTP CONNECT handling.\n\nIf unset, CONNECT requests are rejected with Method Not Allowed.",
@@ -5402,8 +6071,7 @@
               "required": [
                 "mode"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "http": {
               "description": "Settings for managing incoming HTTP requests.",
@@ -5418,6 +6086,7 @@
                 },
                 "http1IdleTimeout": {
                   "description": "Timeout before an unused connection is\nclosed.\nIf unset, this defaults to 10 minutes.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -5488,6 +6157,7 @@
                   ]
                 },
                 "http2KeepaliveInterval": {
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -5501,6 +6171,7 @@
                   ]
                 },
                 "http2KeepaliveTimeout": {
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -5578,6 +6249,7 @@
                 },
                 "maxConnectionDuration": {
                   "description": "Maximum time a connection is allowed to remain open.\nAfter this duration, the connection is gracefully closed after the current in-flight request completes.\nUseful for ensuring even traffic distribution behind load balancers during scaling events.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -5597,8 +6269,7 @@
                   "message": "at least one of the fields in [http1HeaderCase http1IdleTimeout http1MaxHeaders http2ConnectionWindowSize http2FrameSize http2KeepaliveInterval http2KeepaliveTimeout http2MaxHeaderSize http2WindowSize maxBufferSize maxConnectionDuration] must be set",
                   "rule": "[has(self.http1HeaderCase),has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConnectionDuration)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "metrics": {
               "description": "Custom Prometheus metric label configuration.\nCEL expressions are evaluated per-request and added as labels to all\nPrometheus metrics exposed by agentgateway.",
@@ -5626,8 +6297,7 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -5644,15 +6314,13 @@
                       "message": "at least one of the fields in [add] must be set",
                       "rule": "[has(self.add)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "required": [
                 "attributes"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "networkAuthorization": {
               "description": "CEL authorization on downstream network connections.\n\nThis runs before protocol handling and is intended for L4 access control,\nfor example using `source.address` with `cidr(...).containsIP(...)`.",
@@ -5668,7 +6336,7 @@
                   "type": "string"
                 },
                 "policy": {
-                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\n`Deny` is not recommended because expression failures fail to deny; prefer\n`Allow` or `Require`. If used, design expressions defensively against evaluation errors.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
                   "properties": {
                     "matchExpressions": {
                       "description": "CEL expressions that must all evaluate to true for the rule to match.",
@@ -5686,15 +6354,13 @@
                   "required": [
                     "matchExpressions"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "required": [
                 "policy"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "proxyProtocol": {
               "description": "Settings for downstream PROXY protocol handling.\n\nIf configured, incoming connections may require a PROXY header before\nnormal protocol handling. This can also be configured to allow both\nPROXY and non-PROXY traffic on the same listener.",
@@ -5719,8 +6385,7 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "tcp": {
               "description": "Settings for managing incoming TCP connections.",
@@ -5730,6 +6395,7 @@
                   "properties": {
                     "interval": {
                       "description": "Time between keepalive probes.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -5751,6 +6417,7 @@
                     },
                     "time": {
                       "description": "Time a connection needs to be idle before keepalive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "maxLength": 32,
                       "type": "string",
                       "x-kubernetes-validations": [
                         {
@@ -5764,8 +6431,7 @@
                       ]
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -5774,8 +6440,7 @@
                   "message": "at least one of the fields in [keepalive] must be set",
                   "rule": "[has(self.keepalive)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tls": {
               "description": "Settings for managing incoming TLS connections.",
@@ -5811,6 +6476,7 @@
                 },
                 "handshakeTimeout": {
                   "description": "Deadline for a TLS handshake to\ncomplete. If unset, this defaults to `15s`.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -5859,8 +6525,7 @@
                   "message": "at least one of the fields in [alpnProtocols cipherSuites handshakeTimeout keyExchangeGroups maxProtocolVersion minProtocolVersion] must be set",
                   "rule": "[has(self.alpnProtocols),has(self.cipherSuites),has(self.handshakeTimeout),has(self.keyExchangeGroups),has(self.maxProtocolVersion),has(self.minProtocolVersion)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "tracing": {
               "description": "OpenTelemetry tracing settings.",
@@ -5888,8 +6553,7 @@
                           "expression",
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "minItems": 1,
                       "type": "array"
@@ -5912,22 +6576,21 @@
                       "message": "at least one of the fields in [add remove] must be set",
                       "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "backendRef": {
                   "description": "OTLP server to reach.\nSupported types: `Service` and `AgentgatewayBackend`.",
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -5940,14 +6603,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -5963,11 +6626,16 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "clientSampling": {
                   "description": "Expression that determines the amount of client\nsampling. Client sampling determines whether to initiate a new trace\nspan if the incoming request does have a trace already. This should\nevaluate to a float between `0.0` and `1.0`, or a boolean (`true` or\n`false`). If unspecified, client sampling is `100%` enabled.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "filter": {
+                  "description": "Expression that determines whether a sampled span is exported.\nThis uses keep semantics: spans are exported only when the expression\nevaluates to `true`. If unspecified, all sampled spans are exported.",
                   "maxLength": 16384,
                   "minLength": 1,
                   "type": "string"
@@ -6013,8 +6681,7 @@
                       "expression",
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 }
@@ -6032,8 +6699,7 @@
                   "message": "path must start with /",
                   "rule": "!has(self.path) || self.path.startsWith('/')"
                 }
-              ],
-              "additionalProperties": false
+              ]
             }
           },
           "type": "object",
@@ -6042,8 +6708,7 @@
               "message": "at least one of the fields in [accessLog connect http metrics networkAuthorization proxyProtocol tcp tls tracing] must be set",
               "rule": "[has(self.accessLog),has(self.connect),has(self.http),has(self.metrics),has(self.networkAuthorization),has(self.proxyProtocol),has(self.tcp),has(self.tls),has(self.tracing)].filter(x,x==true).size() >= 1"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "strategy": {
           "description": "Policy merge and conflict resolution strategy.\n\nStrategy settings apply to the policy object as a whole. Individual strategy fields may\nonly be valid for specific policy kinds; for example, inheritance is only valid when this\npolicy contains traffic settings.",
@@ -6057,13 +6722,12 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "targetRefs": {
           "description": "Target resources to attach the\npolicy to.",
           "items": {
-            "description": "Selects one same-namespace object by `group`, `kind`, `name`, and,\noptionally, `sectionName`.\nThe object must be in the same namespace as the policy.",
+            "description": "Selects one same-namespace object by `group`, `kind`, `name`, and,\noptionally, `sectionName` or `port`.\nThe object must be in the same namespace as the policy.",
             "properties": {
               "group": {
                 "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
@@ -6084,6 +6748,13 @@
                 "minLength": 1,
                 "type": "string"
               },
+              "port": {
+                "description": "The port of the target resource this policy applies to.\nAt most one of `sectionName` or `port` may be set.\nOnly valid on frontend policies targeting a `Gateway`.",
+                "format": "int32",
+                "maximum": 65535,
+                "minimum": 1,
+                "type": "integer"
+              },
               "sectionName": {
                 "description": "The named section of the target resource.",
                 "maxLength": 253,
@@ -6098,7 +6769,12 @@
               "name"
             ],
             "type": "object",
-            "additionalProperties": false
+            "x-kubernetes-validations": [
+              {
+                "message": "at most one of the fields in [sectionName port] may be set",
+                "rule": "[has(self.sectionName),has(self.port)].filter(x,x==true).size() <= 1"
+              }
+            ]
           },
           "maxItems": 16,
           "minItems": 1,
@@ -6140,6 +6816,13 @@
                 "description": "Labels that must be present on each selected target resource.",
                 "type": "object"
               },
+              "port": {
+                "description": "The port of each selected target resource this policy applies to.\nAt most one of `sectionName` or `port` may be set.\nOnly valid on frontend policies targeting a `Gateway`.",
+                "format": "int32",
+                "maximum": 65535,
+                "minimum": 1,
+                "type": "integer"
+              },
               "sectionName": {
                 "description": "The named section of each selected target resource.",
                 "maxLength": 253,
@@ -6154,7 +6837,12 @@
               "matchLabels"
             ],
             "type": "object",
-            "additionalProperties": false
+            "x-kubernetes-validations": [
+              {
+                "message": "at most one of the fields in [sectionName port] may be set",
+                "rule": "[has(self.sectionName),has(self.port)].filter(x,x==true).size() <= 1"
+              }
+            ]
           },
           "maxItems": 16,
           "minItems": 1,
@@ -6176,6 +6864,22 @@
             "apiKeyAuthentication": {
               "description": "Authenticates users based on a configured API\nkey.",
               "properties": {
+                "configMapSelector": {
+                  "description": "Selects multiple Kubernetes `ConfigMap` resources\ncontaining API keys. It is ConfigMap-only; use `secretRef` or\n`secretSelector` for Secret-backed credentials. If the same key is\ndefined in multiple ConfigMaps, the behavior is undefined.\n\nBecause ConfigMaps are not confidential, every entry sourced from a\nConfigMap must use `keyHash`; a raw `key` value is rejected.\n\nEach entry in the `ConfigMap` data represents one API key. The key is\nan arbitrary identifier. The value must be a JSON object with\n`keyHash`, plus optional `metadata`. `keyHash` contains a hashed API\nkey in `sha256:<hex>` format. `metadata` contains arbitrary JSON\nmetadata associated with the key, which may be used by other\npolicies. For example, you may write an authorization policy allowing\n`apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: ConfigMap\n\tmetadata:\n\t  name: api-key\n\tdata:\n\t  client1: |\n\t    {\n\t      \"keyHash\": \"sha256:efa299afb8c12a36e47a790cbbf929caa06d13285950410463fb759af17d0dad\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\"\n\t      }\n\t    }",
+                  "properties": {
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels that must be present on each selected ConfigMap.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "matchLabels"
+                  ],
+                  "type": "object"
+                },
                 "location": {
                   "description": "Where API keys are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
                   "properties": {
@@ -6190,8 +6894,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -6202,7 +6905,7 @@
                     "header": {
                       "properties": {
                         "name": {
-                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                           "maxLength": 256,
                           "minLength": 1,
                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -6217,8 +6920,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "queryParameter": {
                       "properties": {
@@ -6231,8 +6933,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -6241,8 +6942,7 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "mode": {
                   "default": "Strict",
@@ -6255,18 +6955,18 @@
                   "type": "string"
                 },
                 "secretRef": {
-                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing a set of API keys. If there are many Secret-backed\nkeys, `secretSelector` can be used instead.\n\nEach entry in the credential data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing a set of API keys. If many keys are needed,\n`secretSelector` or `configMapSelector` can be used instead.\nNote that ConfigMap-backed API keys only support `keyHash`.\n\nEach entry in the credential data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with `key` or `keyHash`, plus optional `metadata`.\n  `key` contains the API key. `keyHash` contains a hashed API key in\n  `sha256:<hex>` format. `metadata` contains arbitrary JSON metadata\n  associated with the key, which may be used by other policies. For\n  example, you may write an authorization policy allowing\n  `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"\n\t  client3: |\n\t    {\n\t      \"keyHash\": \"sha256:efa299afb8c12a36e47a790cbbf929caa06d13285950410463fb759af17d0dad\",\n\t      \"metadata\": {\n\t        \"group\": \"engineering\"\n\t      }\n\t    }",
                   "properties": {
                     "group": {
-                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "description": "API group of the referenced credential; empty selects the core API group",
                       "type": "string"
                     },
                     "kind": {
-                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                       "type": "string"
                     },
                     "name": {
-                      "description": "The name of the referenced credential.",
+                      "description": "Name of the referenced credential",
                       "maxLength": 253,
                       "minLength": 1,
                       "type": "string"
@@ -6282,11 +6982,10 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "secretSelector": {
-                  "description": "Selects multiple Kubernetes `Secret` resources\ncontaining API keys. It is Secret-only; use `secretRef` for other\ncredential kinds. If the same key is defined in multiple secrets, the\nbehavior is undefined.\n\nEach entry in the `Secret` data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "description": "Selects multiple Kubernetes `Secret` resources\ncontaining API keys. It is Secret-only; use `secretRef` for other\ncredential kinds. If the same key is defined in multiple secrets, the\nbehavior is undefined.\n\nEach entry in the `Secret` data represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with `key` or `keyHash`, plus optional `metadata`.\n  `key` contains the API key. `keyHash` contains a hashed API key in\n  `sha256:<hex>` format. `metadata` contains arbitrary JSON metadata\n  associated with the key, which may be used by other policies. For\n  example, you may write an authorization policy allowing\n  `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
                   "properties": {
                     "matchLabels": {
                       "additionalProperties": {
@@ -6299,18 +6998,16 @@
                   "required": [
                     "matchLabels"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
-                  "message": "exactly one of the fields in [secretRef secretSelector] must be set",
-                  "rule": "[has(self.secretRef),has(self.secretSelector)].filter(x,x==true).size() == 1"
+                  "message": "exactly one of the fields in [secretRef secretSelector configMapSelector] must be set",
+                  "rule": "[has(self.secretRef),has(self.secretSelector),has(self.configMapSelector)].filter(x,x==true).size() == 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "authorization": {
               "description": "Access rules based on roles and\npermissions.\nIf multiple authorization rules are applied across different policies, at the same or different attachment points,\nall rules are merged.",
@@ -6326,7 +7023,7 @@
                   "type": "string"
                 },
                 "policy": {
-                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\nA CEL expression that fails to evaluate does not match. Prefer `Require`\nfor deny-by-default behavior.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
+                  "description": "The authorization rule to evaluate.\n\n* `Allow`: any matching allow rule allows the request.\n* `Require`: every require rule must match for the request to be allowed.\n* `Deny`: any matching deny rule denies the request.\n\n`Deny` is not recommended because expression failures fail to deny; prefer\n`Allow` or `Require`. If used, design expressions defensively against evaluation errors.\n\nIf at least one `Allow` rule is configured, requests are denied unless at\nleast one allow rule matches.",
                   "properties": {
                     "matchExpressions": {
                       "description": "CEL expressions that must all evaluate to true for the rule to match.",
@@ -6344,15 +7041,13 @@
                   "required": [
                     "matchExpressions"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "required": [
                 "policy"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "basicAuthentication": {
               "description": "Authenticates users based on the `Basic`\nauthentication scheme (RFC 7617), where a username and password are\nencoded in the request.",
@@ -6371,8 +7066,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -6383,7 +7077,7 @@
                     "header": {
                       "properties": {
                         "name": {
-                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                           "maxLength": 256,
                           "minLength": 1,
                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -6398,8 +7092,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "queryParameter": {
                       "properties": {
@@ -6412,8 +7105,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -6422,8 +7114,7 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "mode": {
                   "default": "Strict",
@@ -6439,18 +7130,24 @@
                   "type": "string"
                 },
                 "secretRef": {
-                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the `.htaccess` file. When using the default Secret\nresolver, the `Secret` must have a key named `.htaccess`, and should\ncontain the complete `.htaccess` file.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: basic-auth\n\tstringData:\n\t  .htaccess: |\n\t    alice:$apr1$3zSE0Abt$IuETi4l5yO87MuOrbSE4V.\n\t    bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/",
+                  "description": "Credential source, defaulting to a Kubernetes\n`Secret`, storing the `.htaccess` file. When using the default Secret\nresolver, the `Secret` must have a key named `.htaccess` by default;\noverride via `secretRef.key`. The value should contain the complete\n`.htaccess` file.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: basic-auth\n\tstringData:\n\t  .htaccess: |\n\t    alice:$apr1$3zSE0Abt$IuETi4l5yO87MuOrbSE4V.\n\t    bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/",
                   "properties": {
                     "group": {
-                      "description": "The API group of the referenced credential.\nEmpty selects the core API group.",
+                      "description": "API group of the referenced credential; empty selects the core API group",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Key in the referenced Secret. If omitted, a location-specific default is used",
+                      "maxLength": 253,
+                      "minLength": 1,
                       "type": "string"
                     },
                     "kind": {
-                      "description": "The kind of the referenced credential.\nEmpty defaults to `Secret`.",
+                      "description": "Kind of the referenced credential; empty defaults to `Secret`",
                       "type": "string"
                     },
                     "name": {
-                      "description": "The name of the referenced credential.",
+                      "description": "Name of the referenced credential",
                       "maxLength": 253,
                       "minLength": 1,
                       "type": "string"
@@ -6466,8 +7163,7 @@
                       "message": "custom credential refs must set both group and kind",
                       "rule": "(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "users": {
                   "description": "Inline list of username and password pairs that will\nbe accepted. Each entry represents one line of the `htpasswd` format:\nhttps://httpd.apache.org/docs/2.4/programs/htpasswd.html.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tusers:\n\t- \"user1:$apr1$ivPt0D4C$DmRhnewfHRSrb3DQC.WHC.\"\n\t- \"user2:$2y$05$r3J4d3VepzFkedkd/q1vI.pBYIpSqjfN0qOARV3ScUHysatnS0cL2\"",
@@ -6485,8 +7181,7 @@
                   "message": "exactly one of the fields in [users secretRef] must be set",
                   "rule": "[has(self.users),has(self.secretRef)].filter(x,x==true).size() == 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "buffer": {
               "description": "Buffers request and response bodies. Buffered bodies are accumulated in memory\nby the proxy until completion before being forwarded. This changes the proxies default behavior, which streams bodies.\n\nWarning: large bodies can lead to excessive memory usage in the proxy. Utilize with care, or with strict limits.",
@@ -6494,6 +7189,14 @@
                 "request": {
                   "description": "Request body buffering settings.",
                   "properties": {
+                    "failureMode": {
+                      "description": "Behavior when the request or response body exceeds the buffer limit.\nIf unset, defaults to FailClosed, returning 413 for oversized requests and 502 for oversized responses.",
+                      "enum": [
+                        "FailClosed",
+                        "FailOpen"
+                      ],
+                      "type": "string"
+                    },
                     "maxBytes": {
                       "anyOf": [
                         {
@@ -6516,12 +7219,19 @@
                       ]
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "response": {
                   "description": "Response body buffering settings.",
                   "properties": {
+                    "failureMode": {
+                      "description": "Behavior when the request or response body exceeds the buffer limit.\nIf unset, defaults to FailClosed, returning 413 for oversized requests and 502 for oversized responses.",
+                      "enum": [
+                        "FailClosed",
+                        "FailOpen"
+                      ],
+                      "type": "string"
+                    },
                     "maxBytes": {
                       "anyOf": [
                         {
@@ -6544,8 +7254,7 @@
                       ]
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -6554,8 +7263,7 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "cors": {
               "description": "CORS configuration for the policy.",
@@ -6565,9 +7273,9 @@
                   "type": "boolean"
                 },
                 "allowHeaders": {
-                  "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `allowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `allowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Headers` request header.\n\nIf the configuration contains the wildcard `*` in `allowHeaders` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Headers` response header. Instead, it must\nreturn one or more header names matching the value of the\n`Access-Control-Request-Headers` request header.\nIf the `Access-Control-Request-Headers` header is not present in the\nrequest, the gateway must omit the `Access-Control-Allow-Headers`\nresponse header.\n\nSupport: Extended",
+                  "description": "Request headers allowed when accessing the resource, or `*` for all. Sets `Access-Control-Allow-Headers`. Support: Extended",
                   "items": {
-                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                     "maxLength": 256,
                     "minLength": 1,
                     "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -6584,7 +7292,7 @@
                   ]
                 },
                 "allowMethods": {
-                  "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `allowMethods` field.\n\nWhen the `allowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `allowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Access-Control-Request-Method` request header.\n\nIf the configuration contains the wildcard `*` in `allowMethods` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Methods` response header. Instead, it must\nreturn a single HTTP method matching the value of the\n`Access-Control-Request-Method` request header.\nIf the `Access-Control-Request-Method` header is not present in the request,\nthe gateway must omit the `Access-Control-Allow-Methods` response header.\n\nSupport: Extended",
+                  "description": "HTTP methods allowed for the resource, or `*` for all. CORS-safelisted methods (`GET`, `HEAD`, `POST`) are always allowed. Sets `Access-Control-Allow-Methods`. Support: Extended",
                   "items": {
                     "enum": [
                       "GET",
@@ -6611,7 +7319,7 @@
                   ]
                 },
                 "allowOrigins": {
-                  "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `allowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`\nresponse header may either contain the wildcard `*` or echo the value\nof the `Origin` request header.\n\nIf the configuration contains the wildcard `*` in `allowOrigins` and\n`allowCredentials` is set to `true`, the gateway must not return `*`\nin the `Access-Control-Allow-Origin` response header. Instead, it must\nreturn a single origin matching the value of the `Origin` request header.\n\nSupport: Extended",
+                  "description": "Origins allowed to share the response, each as `<scheme>://<host>(:<port>)`; the host may use the `*` wildcard, and a bare `*` allows all origins. Sets `Access-Control-Allow-Origin`. When credentials are allowed, a specific origin is echoed instead of `*`. Support: Extended",
                   "items": {
                     "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (\"http\" or \"https\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.",
                     "maxLength": 253,
@@ -6630,9 +7338,9 @@
                   ]
                 },
                 "exposeHeaders": {
-                  "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `exposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`\nresponse header can contain the wildcard `*`.\n\nIf the configuration contains the wildcard `*` in `exposeHeaders` and\n`allowCredentials` is set to `true`, the gateway cannot use the `*`\nin the `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
+                  "description": "Response headers exposed to client scripts, or `*` for all. Sets `Access-Control-Expose-Headers`. Support: Extended",
                   "items": {
-                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                     "maxLength": 256,
                     "minLength": 1,
                     "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -6651,8 +7359,7 @@
                 }
               },
               "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true,
-              "additionalProperties": false
+              "x-kubernetes-preserve-unknown-fields": true
             },
             "csrf": {
               "description": "Cross-Site Request Forgery (CSRF) policy for this traffic policy.\n\nThe CSRF policy has the following behavior:\n* Safe methods (`GET`, `HEAD`, `OPTIONS`) are automatically allowed.\n* Requests without `Sec-Fetch-Site` or `Origin` headers are assumed to\n  be same-origin or non-browser requests and are allowed.\n* Otherwise, the `Sec-Fetch-Site` header is checked, with a fallback to\n  comparing the `Origin` header to the `Host` header.",
@@ -6669,8 +7376,22 @@
                   "type": "array"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
+            },
+            "delay": {
+              "description": "Injects artificial latency before forwarding requests, for\nfault-injection testing.",
+              "properties": {
+                "duration": {
+                  "description": "Latency to inject before forwarding the request to the backend. Either a duration string such\nas `2s`, or a CEL expression evaluated against the request that returns a duration (e.g.\n`duration(\"500ms\")`) or a number interpreted as milliseconds (e.g. `random() < 0.1 ? 500 : 0`\nfor probabilistic delay, or `int(random() * 500)` for jitter). A non-positive result injects\nno delay.\n\nThe injected delay counts against the request timeout.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "duration"
+              ],
+              "type": "object"
             },
             "directResponse": {
               "description": "Sends a direct response to the\nclient.",
@@ -6734,8 +7455,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -6763,15 +7483,13 @@
                             "message": "body and bodyExpression may not both be set",
                             "rule": "!(has(self.body) && has(self.bodyExpression))"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -6805,8 +7523,7 @@
                       "name",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -6838,8 +7555,7 @@
                   "message": "status: Required value",
                   "rule": "has(self.conditional) ? true : has(self.status)"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "extAuth": {
               "description": "External authentication configuration for the policy.\nThis selects the external server to send requests to for authentication.\n\nAn extAuth policy can be conditionally set by nesting configuration under the `conditional` field.",
@@ -6849,14 +7565,14 @@
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -6869,14 +7585,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -6892,11 +7608,10 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "cache": {
-                  "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                  "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
                   "properties": {
                     "key": {
                       "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
@@ -6927,8 +7642,7 @@
                     "key",
                     "ttl"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "conditional": {
                   "description": "Conditional policy execution. Set this or the top-level extAuth fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
@@ -6948,14 +7662,14 @@
                             "properties": {
                               "group": {
                                 "default": "",
-                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                 "maxLength": 253,
                                 "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                 "type": "string"
                               },
                               "kind": {
                                 "default": "Service",
-                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                 "maxLength": 63,
                                 "minLength": 1,
                                 "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -6968,14 +7682,14 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                 "maxLength": 63,
                                 "minLength": 1,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                 "type": "string"
                               },
                               "port": {
-                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                 "format": "int32",
                                 "maximum": 65535,
                                 "minimum": 1,
@@ -6991,11 +7705,10 @@
                                 "message": "Must have port for Service reference",
                                 "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "cache": {
-                            "description": "Caches gRPC authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
+                            "description": "Caches authorization results.\n\nWARNING: the safety of this feature depends on the cache key accurately\ncapturing every request property that the authorization service uses to\nmake a decision. For example, if the service returns different results\nbased on both path and authorization header, both must be included in\n`key`; otherwise, one request may incorrectly reuse another request's\nauthorization result.\n\nIf any key expression fails to evaluate or produces an unsupported value,\nthe request is still sent to the authorization service, but its result is\nnot read from or written to the cache.",
                             "properties": {
                               "key": {
                                 "description": "Ordered list of CEL expressions evaluated against the request\nto construct the cache key.",
@@ -7026,8 +7739,7 @@
                               "key",
                               "ttl"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureMode": {
                             "description": "Behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
@@ -7065,8 +7777,7 @@
                             "required": [
                               "maxSize"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "grpc": {
                             "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -7091,8 +7802,7 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "http": {
                             "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -7128,6 +7838,12 @@
                                 "maxItems": 64,
                                 "type": "array"
                               },
+                              "body": {
+                                "description": "Body is a CEL expression that produces the HTTP authorization request body.\nStrings and bytes are used directly; other values are JSON-encoded.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
                               "path": {
                                 "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
                                 "maxLength": 16384,
@@ -7152,8 +7868,7 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -7167,18 +7882,16 @@
                             "rule": "[has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
                           },
                           {
-                            "message": "cache requires grpc",
-                            "rule": "!has(self.cache) || has(self.grpc)"
+                            "message": "forwardBody cannot be used with http.body",
+                            "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -7226,8 +7939,7 @@
                   "required": [
                     "maxSize"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "grpc": {
                   "description": "Uses the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
@@ -7252,8 +7964,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "http": {
                   "description": "Uses HTTP to connect to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
@@ -7289,6 +8000,12 @@
                       "maxItems": 64,
                       "type": "array"
                     },
+                    "body": {
+                      "description": "Body is a CEL expression that produces the HTTP authorization request body.\nStrings and bytes are used directly; other values are JSON-encoded.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
                     "path": {
                       "description": "Path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
                       "maxLength": 16384,
@@ -7313,8 +8030,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -7324,8 +8040,8 @@
                   "rule": "has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
                 },
                 {
-                  "message": "cache requires grpc",
-                  "rule": "!has(self.cache) || has(self.grpc)"
+                  "message": "forwardBody cannot be used with http.body",
+                  "rule": "!(has(self.forwardBody) && has(self.http) && has(self.http.body))"
                 },
                 {
                   "message": "conditional cannot be set with any other field",
@@ -7335,8 +8051,7 @@
                   "message": "backendRef: Required value",
                   "rule": "has(self.conditional) ? true : has(self.backendRef)"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "extProc": {
               "description": "External processing configuration for the policy.",
@@ -7346,14 +8061,14 @@
                   "properties": {
                     "group": {
                       "default": "",
-                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                       "maxLength": 253,
                       "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                       "type": "string"
                     },
                     "kind": {
                       "default": "Service",
-                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -7366,14 +8081,14 @@
                       "type": "string"
                     },
                     "namespace": {
-                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                       "maxLength": 63,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
                     "port": {
-                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                       "format": "int32",
                       "maximum": 65535,
                       "minimum": 1,
@@ -7389,8 +8104,7 @@
                       "message": "Must have port for Service reference",
                       "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "conditional": {
                   "description": "Conditional policy execution. Set this or the top-level extProc fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
@@ -7410,14 +8124,14 @@
                             "properties": {
                               "group": {
                                 "default": "",
-                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                 "maxLength": 253,
                                 "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                 "type": "string"
                               },
                               "kind": {
                                 "default": "Service",
-                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                 "maxLength": 63,
                                 "minLength": 1,
                                 "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -7430,14 +8144,14 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                 "maxLength": 63,
                                 "minLength": 1,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                 "type": "string"
                               },
                               "port": {
-                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                 "format": "int32",
                                 "maximum": 65535,
                                 "minimum": 1,
@@ -7453,8 +8167,30 @@
                                 "message": "Must have port for Service reference",
                                 "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                               }
+                            ]
+                          },
+                          "failureMode": {
+                            "description": "Behavior when the external processor is unavailable or returns an error.\n\"FailOpen\" allows the request to continue, as long as the request body has not\nbeen sent (or started streaming) to the ext_proc. Once the request body has\nstarted streaming to the ext_proc, the request will fail closed on error.\n\"FailClosed\" (default) rejects the request on any failure.",
+                            "enum": [
+                              "FailClosed",
+                              "FailOpen"
                             ],
-                            "additionalProperties": false
+                            "type": "string"
+                          },
+                          "metadataContext": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "description": "A Common Expression Language (CEL) expression.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "description": "NamespacedMetadataContext holds the CEL expressions for a single metadata\nnamespace, keyed by the metadata key within that namespace.",
+                              "type": "object"
+                            },
+                            "description": "Metadata to send to the external processor in the\n`metadata_context.filter_metadata` field of the ProcessingRequest.\nKeyed by metadata namespace, then by key within that namespace; values are\nCEL expressions evaluated per request.",
+                            "maxProperties": 64,
+                            "type": "object"
                           },
                           "processingOptions": {
                             "description": "How request and response phases are sent to ext_proc.",
@@ -7468,10 +8204,10 @@
                                 "default": "FullDuplexStreamed",
                                 "description": "How request bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
                                 "enum": [
-                                  "None",
                                   "Buffered",
                                   "BufferedPartial",
-                                  "FullDuplexStreamed"
+                                  "FullDuplexStreamed",
+                                  "None"
                                 ],
                                 "type": "string"
                               },
@@ -7488,8 +8224,8 @@
                                 "default": "Send",
                                 "description": "Whether request trailers are sent to the external processor.\nDefaults to `Send`.",
                                 "enum": [
-                                  "Skip",
-                                  "Send"
+                                  "Send",
+                                  "Skip"
                                 ],
                                 "type": "string"
                               },
@@ -7497,10 +8233,10 @@
                                 "default": "FullDuplexStreamed",
                                 "description": "How response bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
                                 "enum": [
-                                  "None",
                                   "Buffered",
                                   "BufferedPartial",
-                                  "FullDuplexStreamed"
+                                  "FullDuplexStreamed",
+                                  "None"
                                 ],
                                 "type": "string"
                               },
@@ -7517,14 +8253,35 @@
                                 "default": "Send",
                                 "description": "Whether response trailers are sent to the external processor.\nDefaults to `Send`.",
                                 "enum": [
-                                  "Skip",
-                                  "Send"
+                                  "Send",
+                                  "Skip"
                                 ],
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
+                          },
+                          "requestAttributes": {
+                            "additionalProperties": {
+                              "description": "A Common Expression Language (CEL) expression.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "description": "Request attributes to send to the external processor in the request\n`attributes` field of the ProcessingRequest. Values are CEL expressions\nevaluated per request.",
+                            "maxProperties": 64,
+                            "type": "object"
+                          },
+                          "responseAttributes": {
+                            "additionalProperties": {
+                              "description": "A Common Expression Language (CEL) expression.",
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "description": "Response attributes to send to the external processor in the response\n`attributes` field of the ProcessingRequest. Values are CEL expressions\nevaluated per response.",
+                            "maxProperties": 64,
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -7533,15 +8290,13 @@
                             "message": "backendRef is required",
                             "rule": "has(self.backendRef)"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -7552,6 +8307,29 @@
                       "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
                     }
                   ]
+                },
+                "failureMode": {
+                  "description": "Behavior when the external processor is unavailable or returns an error.\n\"FailOpen\" allows the request to continue, as long as the request body has not\nbeen sent (or started streaming) to the ext_proc. Once the request body has\nstarted streaming to the ext_proc, the request will fail closed on error.\n\"FailClosed\" (default) rejects the request on any failure.",
+                  "enum": [
+                    "FailClosed",
+                    "FailOpen"
+                  ],
+                  "type": "string"
+                },
+                "metadataContext": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "description": "A Common Expression Language (CEL) expression.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "description": "NamespacedMetadataContext holds the CEL expressions for a single metadata\nnamespace, keyed by the metadata key within that namespace.",
+                    "type": "object"
+                  },
+                  "description": "Metadata to send to the external processor in the\n`metadata_context.filter_metadata` field of the ProcessingRequest.\nKeyed by metadata namespace, then by key within that namespace; values are\nCEL expressions evaluated per request.",
+                  "maxProperties": 64,
+                  "type": "object"
                 },
                 "processingOptions": {
                   "description": "How request and response phases are sent to ext_proc.",
@@ -7565,10 +8343,10 @@
                       "default": "FullDuplexStreamed",
                       "description": "How request bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
                       "enum": [
-                        "None",
                         "Buffered",
                         "BufferedPartial",
-                        "FullDuplexStreamed"
+                        "FullDuplexStreamed",
+                        "None"
                       ],
                       "type": "string"
                     },
@@ -7585,8 +8363,8 @@
                       "default": "Send",
                       "description": "Whether request trailers are sent to the external processor.\nDefaults to `Send`.",
                       "enum": [
-                        "Skip",
-                        "Send"
+                        "Send",
+                        "Skip"
                       ],
                       "type": "string"
                     },
@@ -7594,10 +8372,10 @@
                       "default": "FullDuplexStreamed",
                       "description": "How response bodies are sent to the external processor.\n`Buffered` buffers the full body and returns an error if it exceeds 8KB.\n`BufferedPartial` buffers up to 8KB and sends the buffered prefix if the\nbody exceeds that limit. Defaults to `FullDuplexStreamed`.",
                       "enum": [
-                        "None",
                         "Buffered",
                         "BufferedPartial",
-                        "FullDuplexStreamed"
+                        "FullDuplexStreamed",
+                        "None"
                       ],
                       "type": "string"
                     },
@@ -7614,28 +8392,48 @@
                       "default": "Send",
                       "description": "Whether response trailers are sent to the external processor.\nDefaults to `Send`.",
                       "enum": [
-                        "Skip",
-                        "Send"
+                        "Send",
+                        "Skip"
                       ],
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
+                },
+                "requestAttributes": {
+                  "additionalProperties": {
+                    "description": "A Common Expression Language (CEL) expression.",
+                    "maxLength": 16384,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "description": "Request attributes to send to the external processor in the request\n`attributes` field of the ProcessingRequest. Values are CEL expressions\nevaluated per request.",
+                  "maxProperties": 64,
+                  "type": "object"
+                },
+                "responseAttributes": {
+                  "additionalProperties": {
+                    "description": "A Common Expression Language (CEL) expression.",
+                    "maxLength": 16384,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "description": "Response attributes to send to the external processor in the response\n`attributes` field of the ProcessingRequest. Values are CEL expressions\nevaluated per response.",
+                  "maxProperties": 64,
+                  "type": "object"
                 }
               },
               "type": "object",
               "x-kubernetes-validations": [
                 {
                   "message": "conditional cannot be set with any other field",
-                  "rule": "has(self.conditional) ? [has(self.backendRef),has(self.processingOptions)].filter(x,x==true).size() == 0 : true"
+                  "rule": "has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes)].filter(x,x==true).size() == 0 : true"
                 },
                 {
                   "message": "backendRef: Required value",
                   "rule": "has(self.conditional) ? true : has(self.backendRef)"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "headerModifiers": {
               "description": "Request and response header modification policy.",
@@ -7649,14 +8447,14 @@
                         "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
                         "properties": {
                           "name": {
-                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "description": "Name of the HTTP header, case-insensitive",
                             "maxLength": 256,
                             "minLength": 1,
                             "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "description": "Value for the HTTP header",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -7666,8 +8464,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -7691,14 +8488,14 @@
                         "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
                         "properties": {
                           "name": {
-                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "description": "Name of the HTTP header, case-insensitive",
                             "maxLength": 256,
                             "minLength": 1,
                             "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "description": "Value for the HTTP header",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -7708,8 +8505,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -7719,8 +8515,7 @@
                       "x-kubernetes-list-type": "map"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "response": {
                   "description": "Header changes to apply before returning a response.",
@@ -7731,14 +8526,14 @@
                         "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
                         "properties": {
                           "name": {
-                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "description": "Name of the HTTP header, case-insensitive",
                             "maxLength": 256,
                             "minLength": 1,
                             "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "description": "Value for the HTTP header",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -7748,8 +8543,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -7773,14 +8567,14 @@
                         "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
                         "properties": {
                           "name": {
-                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "description": "Name of the HTTP header, case-insensitive",
                             "maxLength": 256,
                             "minLength": 1,
                             "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
                             "type": "string"
                           },
                           "value": {
-                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "description": "Value for the HTTP header",
                             "maxLength": 4096,
                             "minLength": 1,
                             "type": "string"
@@ -7790,8 +8584,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "type": "array",
@@ -7801,8 +8594,7 @@
                       "x-kubernetes-list-type": "map"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -7811,8 +8603,7 @@
                   "message": "at least one of the fields in [request response] must be set",
                   "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "hostRewrite": {
               "description": "How to rewrite the `Host` header for requests.\n\nIf the `HTTPRoute` `urlRewrite` filter already specifies a host rewrite,\nthis setting is ignored.",
@@ -7829,8 +8620,7 @@
               "required": [
                 "mode"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "jwtAuthentication": {
               "description": "Authenticates users based on JWT tokens.",
@@ -7849,8 +8639,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "expression": {
                       "description": "CEL expression that extracts the credential from the request.",
@@ -7861,7 +8650,7 @@
                     "header": {
                       "properties": {
                         "name": {
-                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "description": "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
                           "maxLength": 256,
                           "minLength": 1,
                           "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
@@ -7876,8 +8665,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "queryParameter": {
                       "properties": {
@@ -7890,8 +8678,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -7900,8 +8687,7 @@
                       "message": "exactly one of the fields in [header queryParameter cookie expression] must be set",
                       "rule": "[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size() == 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "mcp": {
                   "description": "Enables MCP OAuth metadata endpoint handling\nand MCP-specific authentication behavior on top of standard JWT validation.\nWhen set, the gateway will serve the MCP OAuth metadata discovery endpoints.",
@@ -7914,6 +8700,9 @@
                       "description": "Identity provider to use for MCP authentication flows.",
                       "enum": [
                         "Auth0",
+                        "Authentik",
+                        "Descope",
+                        "Entra",
                         "Keycloak",
                         "Okta"
                       ],
@@ -7927,8 +8716,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "mode": {
                   "default": "Strict",
@@ -7944,7 +8732,7 @@
                   "items": {
                     "properties": {
                       "audiences": {
-                        "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 \u00a74.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                        "description": "Allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
                         "items": {
                           "type": "string"
                         },
@@ -7953,7 +8741,7 @@
                         "type": "array"
                       },
                       "issuer": {
-                        "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 \u00a74.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                        "description": "IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
                         "maxLength": 256,
                         "minLength": 1,
                         "type": "string"
@@ -7975,14 +8763,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -7995,14 +8783,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -8018,11 +8806,11 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "cacheDuration": {
                                 "default": "5m",
+                                "maxLength": 32,
                                 "type": "string",
                                 "x-kubernetes-validations": [
                                   {
@@ -8046,8 +8834,7 @@
                               "backendRef",
                               "jwksPath"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -8056,16 +8843,14 @@
                             "message": "exactly one of the fields in [remote inline] must be set",
                             "rule": "[has(self.remote),has(self.inline)].filter(x,x==true).size() == 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "issuer",
                       "jwks"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 64,
                   "minItems": 1,
@@ -8085,8 +8870,7 @@
                   "message": "jwtAuthentication.mcp requires mode Strict",
                   "rule": "!has(self.mcp) || !has(self.mode) || self.mode == 'Strict'"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "phase": {
               "description": "The phase to apply the traffic policy to. If the phase is `PreRouting`,\nthe `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is\ntypically used only when a policy needs to influence the routing\ndecision.\n\nEven when using `PostRouting` mode, the policy can target the\n`Gateway` or `Listener`. This is a helper for applying the policy to all\nroutes under that `Gateway` or `Listener`, and follows the merging logic\ndescribed above.\n\nNote: `PreRouting` and `PostRouting` rules do not merge together. These\nare independent execution phases. That is, all `PreRouting` rules will\nmerge and execute, then all `PostRouting` rules will merge and execute.\n\nIf unset, this defaults to `PostRouting`.",
@@ -8120,14 +8904,14 @@
                                 "properties": {
                                   "group": {
                                     "default": "",
-                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                                     "maxLength": 253,
                                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                                     "type": "string"
                                   },
                                   "kind": {
                                     "default": "Service",
-                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -8140,14 +8924,14 @@
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                                     "maxLength": 63,
                                     "minLength": 1,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "type": "string"
                                   },
                                   "port": {
-                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                                     "format": "int32",
                                     "maximum": 65535,
                                     "minimum": 1,
@@ -8163,8 +8947,7 @@
                                     "message": "Must have port for Service reference",
                                     "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                                   }
-                                ],
-                                "additionalProperties": false
+                                ]
                               },
                               "descriptors": {
                                 "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
@@ -8198,8 +8981,7 @@
                                           "expression",
                                           "name"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "maxItems": 16,
                                       "minItems": 1,
@@ -8217,8 +8999,7 @@
                                   "required": [
                                     "entries"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -8244,8 +9025,7 @@
                               "descriptors",
                               "domain"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "local": {
                             "description": "Local rate limiting policy.",
@@ -8288,8 +9068,7 @@
                                   "message": "exactly one of the fields in [requests tokens] must be set",
                                   "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
                                 }
-                              ],
-                              "additionalProperties": false
+                              ]
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -8302,15 +9081,13 @@
                             "message": "at least one of the fields in [global local] must be set",
                             "rule": "[has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -8330,14 +9107,14 @@
                       "properties": {
                         "group": {
                           "default": "",
-                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "description": "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
                           "maxLength": 253,
                           "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                           "type": "string"
                         },
                         "kind": {
                           "default": "Service",
-                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "description": "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
                           "maxLength": 63,
                           "minLength": 1,
                           "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -8350,14 +9127,14 @@
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "description": "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
                           "maxLength": 63,
                           "minLength": 1,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "type": "string"
                         },
                         "port": {
-                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "description": "Destination port number. Required when the referent is a Kubernetes `Service`",
                           "format": "int32",
                           "maximum": 65535,
                           "minimum": 1,
@@ -8373,8 +9150,7 @@
                           "message": "Must have port for Service reference",
                           "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
                         }
-                      ],
-                      "additionalProperties": false
+                      ]
                     },
                     "descriptors": {
                       "description": "Dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
@@ -8408,8 +9184,7 @@
                                 "expression",
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "maxItems": 16,
                             "minItems": 1,
@@ -8427,8 +9202,7 @@
                         "required": [
                           "entries"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -8454,8 +9228,7 @@
                     "descriptors",
                     "domain"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "local": {
                   "description": "Local rate limiting policy.",
@@ -8498,8 +9271,7 @@
                         "message": "exactly one of the fields in [requests tokens] must be set",
                         "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
                       }
-                    ],
-                    "additionalProperties": false
+                    ]
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -8516,8 +9288,7 @@
                   "message": "conditional cannot be set with any other field",
                   "rule": "has(self.conditional) ? [has(self.global),has(self.local)].filter(x,x==true).size() == 0 : true"
                 }
-              ],
-              "additionalProperties": false
+              ]
             },
             "retry": {
               "description": "Retry policy.",
@@ -8528,7 +9299,7 @@
                   "type": "integer"
                 },
                 "backoff": {
-                  "description": "Backoff specifies the minimum duration a Gateway should wait between\nretry attempts and is represented in Gateway API Duration formatting.\n\nFor example, setting the `rules[].retry.backoff` field to the value\n`100ms` will cause a backend request to first be retried approximately\n100 milliseconds after timing out or receiving a response code configured\nto be retriable.\n\nAn implementation MAY use an exponential or alternative backoff strategy\nfor subsequent retry attempts, MAY cap the maximum backoff duration to\nsome amount greater than the specified minimum, and MAY add arbitrary\njitter to stagger requests, as long as unsuccessful backend requests are\nnot retried before the configured minimum duration.\n\nIf a Request timeout (`rules[].timeouts.request`) is configured on the\nroute, the entire duration of the initial request and any retry attempts\nMUST not exceed the Request timeout duration. If any retry attempts are\nstill in progress when the Request timeout duration has been reached,\nthese SHOULD be canceled if possible and the Gateway MUST immediately\nreturn a timeout error.\n\nIf a BackendRequest timeout (`rules[].timeouts.backendRequest`) is\nconfigured on the route, any retry attempts which reach the configured\nBackendRequest timeout duration without a response SHOULD be canceled if\npossible and the Gateway should wait for at least the specified backoff\nduration before attempting to retry the backend request again.\n\nIf a BackendRequest timeout is _not_ configured on the route, retry\nattempts MAY time out after an implementation default duration, or MAY\nremain pending until a configured Request timeout or implementation\ndefault duration for total request time is reached.\n\nWhen this field is unspecified, the time to wait between retry attempts\nis implementation-specific.\n\nSupport: Extended",
+                  "description": "Minimum duration to wait between retry attempts, in Gateway API Duration format. Implementations may add jitter or use exponential backoff, and must not exceed a configured request timeout. Support: Extended",
                   "pattern": "^([0-9]{1,5}(h|m|s|ms)){1,4}$",
                   "type": "string"
                 },
@@ -8556,14 +9327,14 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "timeouts": {
               "description": "Request timeouts.\nIt is applicable to `HTTPRoute` resources and ignored for other targeted\nkinds.",
               "properties": {
                 "request": {
                   "description": "Timeout for an individual request from the gateway to a backend. This covers the time from when\nthe request first starts being sent from the gateway to when the full response has been received from the backend.",
+                  "maxLength": 32,
                   "type": "string",
                   "x-kubernetes-validations": [
                     {
@@ -8577,8 +9348,7 @@
                   ]
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "transformation": {
               "description": "Mutates and transforms requests and responses\nbefore forwarding them to the destination.",
@@ -8627,8 +9397,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -8704,8 +9473,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -8722,8 +9490,7 @@
                                 "message": "at least one of the fields in [add body metadata remove set] must be set",
                                 "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           },
                           "response": {
                             "description": "Response transformation settings.",
@@ -8756,8 +9523,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -8833,8 +9599,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "maxItems": 16,
                                 "minItems": 1,
@@ -8851,8 +9616,7 @@
                                 "message": "at least one of the fields in [add body metadata remove set] must be set",
                                 "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                               }
-                            ],
-                            "additionalProperties": false
+                            ]
                           }
                         },
                         "type": "object",
@@ -8861,15 +9625,13 @@
                             "message": "at least one of the fields in [request response] must be set",
                             "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
                           }
-                        ],
-                        "additionalProperties": false
+                        ]
                       }
                     },
                     "required": [
                       "policy"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "maxItems": 16,
                   "minItems": 1,
@@ -8912,8 +9674,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -8989,8 +9750,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9007,8 +9767,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 },
                 "response": {
                   "description": "Response transformation settings.",
@@ -9041,8 +9800,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9118,8 +9876,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "maxItems": 16,
                       "minItems": 1,
@@ -9136,8 +9893,7 @@
                       "message": "at least one of the fields in [add body metadata remove set] must be set",
                       "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
                     }
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "type": "object",
@@ -9150,18 +9906,16 @@
                   "message": "conditional cannot be set with any other field",
                   "rule": "has(self.conditional) ? [has(self.request),has(self.response)].filter(x,x==true).size() == 0 : true"
                 }
-              ],
-              "additionalProperties": false
+              ]
             }
           },
           "type": "object",
           "x-kubernetes-validations": [
             {
               "message": "phase PreRouting only supports extAuth, authorization, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors",
-              "rule": "has(self.phase) && self.phase == 'PreRouting' ? [has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size() == 0 : true"
+              "rule": "has(self.phase) && self.phase == 'PreRouting' ? [has(self.buffer),has(self.csrf),has(self.delay),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size() == 0 : true"
             }
-          ],
-          "additionalProperties": false
+          ]
         }
       },
       "type": "object",
@@ -9192,11 +9946,27 @@
         },
         {
           "message": "the 'frontend' field can only target a Gateway",
-          "rule": "has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+          "rule": "has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind == 'Gateway') : true"
         },
         {
           "message": "the 'frontend' field can only target a Gateway",
-          "rule": "has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+          "rule": "has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind == 'Gateway') : true"
+        },
+        {
+          "message": "frontend tcp, networkAuthorization, tls, http, proxyProtocol, and connect policies may only target a Gateway or port, not a listener (sectionName)",
+          "rule": "has(self.frontend) && (has(self.frontend.tcp) || has(self.frontend.networkAuthorization) || has(self.frontend.tls) || has(self.frontend.http) || has(self.frontend.proxyProtocol) || has(self.frontend.connect)) && has(self.targetRefs) ? self.targetRefs.all(t, !has(t.sectionName)) : true"
+        },
+        {
+          "message": "frontend tcp, networkAuthorization, tls, http, proxyProtocol, and connect policies may only target a Gateway or port, not a listener (sectionName)",
+          "rule": "has(self.frontend) && (has(self.frontend.tcp) || has(self.frontend.networkAuthorization) || has(self.frontend.tls) || has(self.frontend.http) || has(self.frontend.proxyProtocol) || has(self.frontend.connect)) && has(self.targetSelectors) ? self.targetSelectors.all(t, !has(t.sectionName)) : true"
+        },
+        {
+          "message": "port may only be set on frontend-only policies (not traffic or backend)",
+          "rule": "has(self.targetRefs) && self.targetRefs.exists(t, has(t.port)) ? (has(self.frontend) && !has(self.traffic) && !has(self.backend)) : true"
+        },
+        {
+          "message": "port may only be set on frontend-only policies (not traffic or backend)",
+          "rule": "has(self.targetSelectors) && self.targetSelectors.exists(t, has(t.port)) ? (has(self.frontend) && !has(self.traffic) && !has(self.backend)) : true"
         },
         {
           "message": "the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool",
@@ -9218,16 +9988,15 @@
           "message": "exactly one of the fields in [targetRefs targetSelectors] must be set",
           "rule": "[has(self.targetRefs),has(self.targetSelectors)].filter(x,x==true).size() == 1"
         }
-      ],
-      "additionalProperties": false
+      ]
     },
     "status": {
       "description": "Current policy status.",
       "properties": {
         "ancestors": {
-          "description": "Ancestors is a list of ancestor resources (usually Gateways) that are\nassociated with the policy, and the status of the policy with respect to\neach ancestor. When this policy attaches to a parent, the controller that\nmanages the parent and the ancestors MUST add an entry to this list when\nthe controller first sees the policy and SHOULD update the entry as\nappropriate when the relevant ancestor is modified.\n\nNote that choosing the relevant ancestor is left to the Policy designers;\nan important part of Policy design is designing the right object level at\nwhich to namespace this status.\n\nNote also that implementations MUST ONLY populate ancestor status for\nthe Ancestor resources they are responsible for. Implementations MUST\nuse the ControllerName field to uniquely identify the entries in this list\nthat they are responsible for.\n\nNote that to achieve this, the list of PolicyAncestorStatus structs\nMUST be treated as a map with a composite key, made up of the AncestorRef\nand ControllerName fields combined.\n\nA maximum of 16 ancestors will be represented in this list. An empty list\nmeans the Policy is not relevant for any ancestors.\n\nIf this slice is full, implementations MUST NOT add further entries.\nInstead they MUST consider the policy unimplementable and signal that\non any related resources such as the ancestor that would be referenced\nhere. For example, if this list was full on BackendTLSPolicy, no\nadditional Gateways would be able to reference the Service targeted by\nthe BackendTLSPolicy.",
+          "description": "Ancestor resources (usually Gateways) associated with the policy, with the policy's status for each. At most 16 entries; an empty list means the policy is not relevant to any ancestor",
           "items": {
-            "description": "PolicyAncestorStatus describes the status of a route with respect to an\nassociated Ancestor.\n\nAncestors refer to objects that are either the Target of a policy or above it\nin terms of object hierarchy. For example, if a policy targets a Service, the\nPolicy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and\nthe GatewayClass. Almost always, in this hierarchy, the Gateway will be the most\nuseful object to place Policy status on, so we recommend that implementations\nSHOULD use Gateway as the PolicyAncestorStatus object unless the designers\nhave a _very_ good reason otherwise.\n\nIn the context of policy attachment, the Ancestor is used to distinguish which\nresource results in a distinct application of this policy. For example, if a policy\ntargets a Service, it may have a distinct result per attached Gateway.\n\nPolicies targeting the same resource may have different effects depending on the\nancestors of those resources. For example, different Gateways targeting the same\nService may have different capabilities, especially if they have different underlying\nimplementations.\n\nFor example, in BackendTLSPolicy, the Policy attaches to a Service that is\nused as a backend in a HTTPRoute that is itself attached to a Gateway.\nIn this case, the relevant object for status is the Gateway, and that is the\nancestor object referred to in this status.\n\nNote that a parent is also an ancestor, so for objects where the parent is the\nrelevant object for status, this struct SHOULD still be used.\n\nThis struct is intended to be used in a slice that's effectively a map,\nwith a composite key made up of the AncestorRef and the ControllerName.",
+            "description": "Status of a policy with respect to an associated ancestor resource, usually a Gateway",
             "properties": {
               "ancestorRef": {
                 "description": "AncestorRef corresponds with a ParentRef in the spec that this\nPolicyAncestorStatus struct describes the status of.",
@@ -9254,21 +10023,21 @@
                     "type": "string"
                   },
                   "namespace": {
-                    "description": "Namespace is the namespace of the referent. When unspecified, this refers\nto the local namespace of the Route.\n\nNote that there are specific rules for ParentRefs which cross namespace\nboundaries. Cross-namespace references are only valid if they are explicitly\nallowed by something in the namespace they are referring to. For example:\nGateway has the AllowedRoutes field, and ReferenceGrant provides a\ngeneric way to enable any other kind of cross-namespace reference.\n\n<gateway:experimental:description>\nParentRefs from a Route to a Service in the same namespace are \"producer\"\nroutes, which apply default routing rules to inbound connections from\nany namespace to the Service.\n\nParentRefs from a Route to a Service in a different namespace are\n\"consumer\" routes, and these routing rules are only applied to outbound\nconnections originating from the same namespace as the Route, for which\nthe intended destination of the connections are a Service targeted as a\nParentRef of the Route.\n</gateway:experimental:description>\n\nSupport: Core",
+                    "description": "Namespace of the referent. Defaults to the Route's local namespace. Cross-namespace references must be explicitly allowed, for example via ReferenceGrant. Support: Core",
                     "maxLength": 63,
                     "minLength": 1,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "type": "string"
                   },
                   "port": {
-                    "description": "Port is the network port this Route targets. It can be interpreted\ndifferently based on the type of parent resource.\n\nWhen the parent resource is a Gateway, this targets all listeners\nlistening on the specified port that also support this kind of Route(and\nselect this Route). It's not recommended to set `Port` unless the\nnetworking behaviors specified in a Route must apply to a specific port\nas opposed to a listener(s) whose port(s) may be changed. When both Port\nand SectionName are specified, the name and port of the selected listener\nmust match both specified values.\n\n<gateway:experimental:description>\nWhen the parent resource is a Service, this targets a specific port in the\nService spec. When both Port (experimental) and SectionName are specified,\nthe name and port of the selected port must match both specified values.\n</gateway:experimental:description>\n\nImplementations MAY choose to support other parent resources.\nImplementations supporting other types of parent resources MUST clearly\ndocument how/if Port is interpreted.\n\nFor the purpose of status, an attachment is considered successful as\nlong as the parent resource accepts it partially. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment\nfrom the referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route,\nthe Route MUST be considered detached from the Gateway.\n\nSupport: Extended",
+                    "description": "Port this Route targets on the parent, interpreted per parent kind (for example a Gateway listener port or Service port). Support: Extended",
                     "format": "int32",
                     "maximum": 65535,
                     "minimum": 1,
                     "type": "integer"
                   },
                   "sectionName": {
-                    "description": "SectionName is the name of a section within the target resource. In the\nfollowing resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n* Service: Port name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n\nImplementations MAY choose to support attaching Routes to other resources.\nIf that is the case, they MUST clearly document how SectionName is\ninterpreted.\n\nWhen unspecified (empty string), this will reference the entire resource.\nFor the purpose of status, an attachment is considered successful if at\nleast one section in the parent resource accepts it. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment from\nthe referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route, the\nRoute MUST be considered detached from the Gateway.\n\nSupport: Core",
+                    "description": "Name of a section within the target resource, for example a Gateway Listener name or Service port name. Empty references the entire resource. Support: Core",
                     "maxLength": 253,
                     "minLength": 1,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -9278,11 +10047,10 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "conditions": {
-                "description": "Conditions describes the status of the Policy with respect to the given Ancestor.\n\n<gateway:util:excludeFromCRD>\n\nNotes for implementors:\n\nConditions are a listType `map`, which means that they function like a\nmap with a key of the `type` field _in the k8s apiserver_.\n\nThis means that implementations must obey some rules when updating this\nsection.\n\n* Implementations MUST perform a read-modify-write cycle on this field\n  before modifying it. That is, when modifying this field, implementations\n  must be confident they have fetched the most recent version of this field,\n  and ensure that changes they make are on that recent version.\n* Implementations MUST NOT remove or reorder Conditions that they are not\n  directly responsible for. For example, if an implementation sees a Condition\n  with type `special.io/SomeField`, it MUST NOT remove, change or update that\n  Condition.\n* Implementations MUST always _merge_ changes into Conditions of the same Type,\n  rather than creating more than one Condition of the same Type.\n* Implementations MUST always update the `observedGeneration` field of the\n  Condition to the `metadata.generation` of the Gateway at the time of update creation.\n* If the `observedGeneration` of a Condition is _greater than_ the value the\n  implementation knows about, then it MUST NOT perform the update on that Condition,\n  but must wait for a future reconciliation and status update. (The assumption is that\n  the implementation's copy of the object is stale and an update will be re-triggered\n  if relevant.)\n\n</gateway:util:excludeFromCRD>",
+                "description": "Conditions describing the status of the policy for this ancestor",
                 "items": {
                   "description": "Condition contains details for one aspect of the current state of this API Resource.",
                   "properties": {
@@ -9332,8 +10100,7 @@
                     "status",
                     "type"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "maxItems": 8,
                 "minItems": 1,
@@ -9356,8 +10123,7 @@
               "conditions",
               "controllerName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "maxItems": 16,
           "type": "array",
@@ -9367,8 +10133,7 @@
       "required": [
         "ancestors"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/index.yaml
+++ b/index.yaml
@@ -203,6 +203,10 @@ agentgateway.dev:
     filename: agentgateway.dev/agentgatewaybackend_v1alpha1.json
     kind: agentgatewaybackend
     name: agentgatewaybackend_v1alpha1
+  - apiVersion: agentgateway.dev/v1alpha1
+    filename: agentgateway.dev/agentgatewaymodel_v1alpha1.json
+    kind: agentgatewaymodel
+    name: agentgatewaymodel_v1alpha1
 aigateway.envoyproxy.io:
   - apiVersion: aigateway.envoyproxy.io/v1beta1
     filename: aigateway.envoyproxy.io/gatewayconfig_v1beta1.json


### PR DESCRIPTION
## PR Checklist

- [x] The schemas were generated with this repository’s `Utilities/openapi2jsonschema.py`; the reproducible method and official source are documented below.
- [x] Existing schemas were updated to Agentgateway v1.4.1.
- [x] Adds the new experimental `AgentgatewayModel` schema from the official source linked below.

## Summary

- Updates the three existing `agentgateway.dev/v1alpha1` schemas—Backend, Parameters, and Policy—to Agentgateway v1.4.1.
- Adds the experimental `AgentgatewayModel` v1alpha1 schema and its `index.yaml` entry, completing the CRD set shipped by the v1.4.1 `agentgateway-crds` Helm chart.
- Preserves catalog-standard strict validation by generating JSON through the repository converter, which sets `additionalProperties: false` on nested typed objects where appropriate.

## Change Type

Chore

## Source and generation method

Source: the official [Agentgateway v1.4.1 Helm CRD templates](https://github.com/agentgateway/agentgateway/tree/v1.4.1/controller/install/helm/agentgateway-crds/templates).

For each CRD template, generated with:

```sh
FILENAME_FORMAT="{kind}_{version}" python3 Utilities/openapi2jsonschema.py <official-v1.4.1-CRD-template>
```

The four generated `v1alpha1` files are registered in `index.yaml` without unrelated index changes.

## Compatibility note

This update intentionally reflects Agentgateway v1.4.1 validation changes. Manifests upgrading from v1.3.x may fail strict validation when prompt-guard `auth` uses credential combinations no longer supported by the upstream CRDs:

- Bedrock Guardrails no longer accepts Azure, GCP, or passthrough auth.
- Google Model Armor now accepts only GCP auth.
- OpenAI Moderation no longer accepts AWS, Azure, GCP, or passthrough auth.

Review affected prompt-guard `auth` configuration before upgrading. The newly added `AgentgatewayModel` API is experimental upstream.

## Verification

- [x] Parsed all four changed schemas with `jq empty`.
- [x] Compared every committed JSON schema semantically with this repository converter’s output from the pinned v1.4.1 source; all match exactly after key sorting.
- [x] Confirmed catalog-standard strict nested-object counts: Backend 508, Parameters 30, Policy 332, Model 181.
- [x] Confirmed zero tabs and zero trailing-whitespace lines in each generated JSON file.
- [x] Ran `git diff --check`; the PR changes only the four intended schemas and the single index entry.
- [x] Ran `kubeconform v0.7.0 -strict` against official Agentgateway v1.4.1 fixtures using this PR’s local schemas: 86 valid resources passed; all 34 intentionally invalid resources were rejected; 0 validator errors.

## Reviewer notes

This PR is intentionally kept as a draft until the author confirms it is ready for external review. The original Agentgateway catalog contribution used the same converter workflow; this update follows that established precedent.