### PR TITLE
Update Infisical CRD's

### DIFF
--- a/secrets.infisical.com/infisicalauth_v1beta1.json
+++ b/secrets.infisical.com/infisicalauth_v1beta1.json
@@ -1,0 +1,447 @@
+{
+  "description": "InfisicalAuth is the Schema for the InfisicalAuth API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "awsIam": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "identityIdRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azure": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resource": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "identityIdRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gcpIam": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountKeyFilePath": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "identityIdRef",
+            "serviceAccountKeyFilePath"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gcpIdToken": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "identityIdRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infisicalConnectionRef": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetes": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountTokenAudiences": {
+              "description": "The audiences to use for the service account token. This is only relevant if `autoCreateServiceAccountToken` is true.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "identityIdRef",
+            "serviceAccountRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ldap": {
+          "properties": {
+            "identityIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "passwordRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "usernameRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "identityIdRef",
+            "passwordRef",
+            "usernameRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "method": {
+          "enum": [
+            "universal",
+            "kubernetes",
+            "aws-iam",
+            "azure",
+            "gcp-id-token",
+            "gcp-iam",
+            "ldap"
+          ],
+          "type": "string"
+        },
+        "universal": {
+          "properties": {
+            "clientIdRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clientSecretRef": {
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "clientIdRef",
+            "clientSecretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "infisicalConnectionRef",
+        "method"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "InfisicalAuthStatus defines the observed state of InfisicalAuth",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets.infisical.com/infisicalconnection_v1beta1.json
+++ b/secrets.infisical.com/infisicalconnection_v1beta1.json
@@ -1,0 +1,122 @@
+{
+  "description": "InfisicalConnection is the Schema for the infisicalconnection API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "InfisicalConnectionSpec defines how the operator connects to a Infisical instance",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "tls": {
+          "properties": {
+            "caCertificate": {
+              "description": "Reference to secret containing CA cert",
+              "properties": {
+                "key": {
+                  "description": "The name of the secret property with the value",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Kubernetes Secret",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "The namespace where the Kubernetes Secret is located",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "InfisicalConnectionStatus defines the observed state of InfisicalConnection",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets.infisical.com/infisicaldynamicsecret_v1alpha1.json
+++ b/secrets.infisical.com/infisicaldynamicsecret_v1alpha1.json
@@ -242,6 +242,27 @@
                 "includeAllSecrets": {
                   "description": "This injects all retrieved secrets into the top level of your template.\nSecrets defined in the template will take precedence over the injected ones.",
                   "type": "boolean"
+                },
+                "metadata": {
+                  "description": "Custom metadata (labels/annotations) for the managed secret.\nWhen specified, these values are used instead of copying metadata from the InfisicalSecret CR.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Custom annotations to apply to the managed secret",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Custom labels to apply to the managed secret",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",

--- a/secrets.infisical.com/infisicalpushsecret_v1alpha1.json
+++ b/secrets.infisical.com/infisicalpushsecret_v1alpha1.json
@@ -274,6 +274,27 @@
                     "includeAllSecrets": {
                       "description": "This injects all retrieved secrets into the top level of your template.\nSecrets defined in the template will take precedence over the injected ones.",
                       "type": "boolean"
+                    },
+                    "metadata": {
+                      "description": "Custom metadata (labels/annotations) for the managed secret.\nWhen specified, these values are used instead of copying metadata from the InfisicalSecret CR.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Custom annotations to apply to the managed secret",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Custom labels to apply to the managed secret",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
                   "type": "object",

--- a/secrets.infisical.com/infisicalsecret_v1alpha1.json
+++ b/secrets.infisical.com/infisicalsecret_v1alpha1.json
@@ -60,6 +60,9 @@
             },
             "azureAuth": {
               "properties": {
+                "azureManagedIdentityClientId": {
+                  "type": "string"
+                },
                 "identityId": {
                   "type": "string"
                 },
@@ -495,6 +498,27 @@
                   "includeAllSecrets": {
                     "description": "This injects all retrieved secrets into the top level of your template.\nSecrets defined in the template will take precedence over the injected ones.",
                     "type": "boolean"
+                  },
+                  "metadata": {
+                    "description": "Custom metadata (labels/annotations) for the managed secret.\nWhen specified, these values are used instead of copying metadata from the InfisicalSecret CR.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom annotations to apply to the managed secret",
+                        "type": "object"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom labels to apply to the managed secret",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
                 "type": "object",
@@ -544,6 +568,27 @@
                   "includeAllSecrets": {
                     "description": "This injects all retrieved secrets into the top level of your template.\nSecrets defined in the template will take precedence over the injected ones.",
                     "type": "boolean"
+                  },
+                  "metadata": {
+                    "description": "Custom metadata (labels/annotations) for the managed secret.\nWhen specified, these values are used instead of copying metadata from the InfisicalSecret CR.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom annotations to apply to the managed secret",
+                        "type": "object"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom labels to apply to the managed secret",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
                 "type": "object",
@@ -592,6 +637,27 @@
                 "includeAllSecrets": {
                   "description": "This injects all retrieved secrets into the top level of your template.\nSecrets defined in the template will take precedence over the injected ones.",
                   "type": "boolean"
+                },
+                "metadata": {
+                  "description": "Custom metadata (labels/annotations) for the managed secret.\nWhen specified, these values are used instead of copying metadata from the InfisicalSecret CR.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Custom annotations to apply to the managed secret",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Custom labels to apply to the managed secret",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
@@ -606,8 +672,19 @@
           "additionalProperties": false
         },
         "resyncInterval": {
-          "default": 60,
           "type": "integer"
+        },
+        "syncConfig": {
+          "properties": {
+            "instantUpdates": {
+              "type": "boolean"
+            },
+            "resyncInterval": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "tls": {
           "properties": {
@@ -658,9 +735,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "resyncInterval"
-      ],
       "type": "object",
       "additionalProperties": false
     },

--- a/secrets.infisical.com/infisicalstaticsecret_v1beta1.json
+++ b/secrets.infisical.com/infisicalstaticsecret_v1beta1.json
@@ -1,0 +1,239 @@
+{
+  "description": "InfisicalStaticSecret is the Schema for the InfisicalStaticSecret API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "infisicalAuthRef": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sources": {
+          "items": {
+            "properties": {
+              "environmentSlug": {
+                "type": "string"
+              },
+              "projectId": {
+                "type": "string"
+              },
+              "projectSlug": {
+                "type": "string"
+              },
+              "recursive": {
+                "type": "boolean"
+              },
+              "secretPath": {
+                "type": "string"
+              },
+              "tagSlugs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "environmentSlug",
+              "secretPath"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "syncOptions": {
+          "properties": {
+            "instantUpdates": {
+              "type": "boolean"
+            },
+            "refreshInterval": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "refreshInterval"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targets": {
+          "items": {
+            "properties": {
+              "creationPolicy": {
+                "enum": [
+                  "Owner",
+                  "Orphan"
+                ],
+                "type": "string"
+              },
+              "kind": {
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "metadata": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "annotations",
+                  "labels"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "secretType": {
+                "type": "string"
+              },
+              "template": {
+                "properties": {
+                  "data": {
+                    "description": "Data defines the templated output. It accepts either a map of per-key\nGo templates (each entry becomes one key in the resulting Secret /\nConfigMap) or a single Go template string whose rendered output is\nYAML-decoded into a map of key/value pairs.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "engineVersion": {
+                    "enum": [
+                      "v1"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data",
+                  "engineVersion"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "creationPolicy",
+              "kind",
+              "name",
+              "namespace"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "infisicalAuthRef",
+        "sources",
+        "syncOptions",
+        "targets"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "InfisicalStaticSecretStatus defines the observed state of InfisicalAuth",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Hello I am from the Infisical team, and I maintain the Kubernetes Operator. I've gone ahead and updated our existing schemas, and added in all our new CRD's for the new v1beta API. Let me know if you need anything else from me, thank you!

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

New CRD's source: https://github.com/Infisical/kubernetes-operator/tree/main/config/crd/bases
