### PR TITLE
Add observability.giantswarm.io Silence v1alpha2 schema (silence-operator v0.20.1)

### DIFF
--- a/observability.giantswarm.io/silence_v1alpha2.json
+++ b/observability.giantswarm.io/silence_v1alpha2.json
@@ -1,0 +1,65 @@
+{
+  "description": "Silence is the Schema for the silences API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SilenceSpec defines the desired state of Silence.",
+      "properties": {
+        "matchers": {
+          "description": "Matchers defines the alert matchers that this silence will apply to.",
+          "items": {
+            "description": "SilenceMatcher defines an alert matcher to be muted by the Silence.",
+            "properties": {
+              "matchType": {
+                "default": "=",
+                "description": "MatchType defines the type of matching to perform.",
+                "enum": [
+                  "=",
+                  "!=",
+                  "=~",
+                  "!~"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the label to match.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value to match for the given label name.",
+                "maxLength": 1024,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "matchers"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Giant Swarm's silence-operator moved Silence from monitoring.giantswarm.io to observability.giantswarm.io. The catalog carries neither group, so kubeconform cannot validate a Silence at all.

Generated with Utilities/openapi2jsonschema.py from the live CRD.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
