### PR TITLE
fix: regenerate kyverno 1.19.0 CRDs with fixed openapi2jsonschema script

### DIFF
--- a/policies.kyverno.io/policyexception_v1.json
+++ b/policies.kyverno.io/policyexception_v1.json
@@ -98,8 +98,7 @@
             "pass"
           ],
           "type": "string"
-        },
-        "additionalProperties": false
+        }
       },
       "required": [
         "policyRefs"

--- a/policies.kyverno.io/policyexception_v1alpha1.json
+++ b/policies.kyverno.io/policyexception_v1alpha1.json
@@ -98,8 +98,7 @@
             "pass"
           ],
           "type": "string"
-        },
-        "additionalProperties": false
+        }
       },
       "required": [
         "policyRefs"

--- a/policies.kyverno.io/policyexception_v1beta1.json
+++ b/policies.kyverno.io/policyexception_v1beta1.json
@@ -98,8 +98,7 @@
             "pass"
           ],
           "type": "string"
-        },
-        "additionalProperties": false
+        }
       },
       "required": [
         "policyRefs"

--- a/reports.kyverno.io/clusterephemeralreport_v1.json
+++ b/reports.kyverno.io/clusterephemeralreport_v1.json
@@ -217,8 +217,7 @@
                 ],
                 "type": "object",
                 "additionalProperties": false
-              },
-              "additionalProperties": false
+              }
             },
             "required": [
               "policy"

--- a/reports.kyverno.io/ephemeralreport_v1.json
+++ b/reports.kyverno.io/ephemeralreport_v1.json
@@ -217,8 +217,7 @@
                 ],
                 "type": "object",
                 "additionalProperties": false
-              },
-              "additionalProperties": false
+              }
             },
             "required": [
               "policy"


### PR DESCRIPTION
Some kyverno 1.19.0 schemas were generated incorrectly due to the `openapi2jsonschema.py` script incorrectly handling `properties` fields appearing in CRDs.

The fixed script can be found in this PR: https://github.com/datreeio/CRDs-catalog/pull/964

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
