### PR TITLE
feat: add Crossplane provider config schemas

### DIFF
--- a/keycloak.crossplane.io/providerconfig_v1beta1.json
+++ b/keycloak.crossplane.io/providerconfig_v1beta1.json
@@ -1,0 +1,161 @@
+{
+  "description": "A ProviderConfig configures a keycloak provider.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "A ProviderConfigSpec defines the desired state of a ProviderConfig.\nA ProviderConfigSpec defines the desired state of a ProviderConfig.",
+      "properties": {
+        "credentials": {
+          "description": "Credentials required to authenticate to this provider.",
+          "properties": {
+            "env": {
+              "description": "Env is a reference to an environment variable that contains credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of an environment variable.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fs": {
+              "description": "Fs is a reference to a filesystem location that contains credentials that\nmust be used to connect to the provider.",
+              "properties": {
+                "path": {
+                  "description": "Path is a filesystem path.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "A SecretRef is a reference to a secret key that contains the credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "key": {
+                  "description": "The key to select.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "source": {
+              "description": "Source of the provider credentials.",
+              "enum": [
+                "None",
+                "Secret",
+                "Environment",
+                "Filesystem"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "source"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "credentials"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "A ProviderConfigStatus reflects the observed state of a ProviderConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "users": {
+          "description": "Users of this provider configuration.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kubernetes.crossplane.io/providerconfig_v1alpha1.json
+++ b/kubernetes.crossplane.io/providerconfig_v1alpha1.json
@@ -1,0 +1,247 @@
+{
+  "description": "A ProviderConfig configures a Template provider.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "A ProviderConfigSpec defines the desired state of a ProviderConfig.",
+      "properties": {
+        "credentials": {
+          "description": "Credentials used to connect to the Kubernetes API. Typically a\nkubeconfig file. Use InjectedIdentity for in-cluster config.",
+          "properties": {
+            "env": {
+              "description": "Env is a reference to an environment variable that contains credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of an environment variable.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fs": {
+              "description": "Fs is a reference to a filesystem location that contains credentials that\nmust be used to connect to the provider.",
+              "properties": {
+                "path": {
+                  "description": "Path is a filesystem path.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "A SecretRef is a reference to a secret key that contains the credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "key": {
+                  "description": "The key to select.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "source": {
+              "description": "Source of the provider credentials.",
+              "enum": [
+                "None",
+                "Secret",
+                "InjectedIdentity",
+                "Environment",
+                "Filesystem"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "source"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identity": {
+          "description": "Identity used to authenticate to the Kubernetes API. The identity\ncredentials can be used to supplement kubeconfig 'credentials', for\nexample by configuring a bearer token source such as OAuth.",
+          "properties": {
+            "env": {
+              "description": "Env is a reference to an environment variable that contains credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of an environment variable.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fs": {
+              "description": "Fs is a reference to a filesystem location that contains credentials that\nmust be used to connect to the provider.",
+              "properties": {
+                "path": {
+                  "description": "Path is a filesystem path.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "A SecretRef is a reference to a secret key that contains the credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "key": {
+                  "description": "The key to select.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "source": {
+              "description": "Source of the provider credentials.",
+              "enum": [
+                "None",
+                "Secret",
+                "InjectedIdentity",
+                "Environment",
+                "Filesystem"
+              ],
+              "type": "string"
+            },
+            "type": {
+              "description": "Type of identity.",
+              "enum": [
+                "GoogleApplicationCredentials",
+                "AzureServicePrincipalCredentials",
+                "AzureWorkloadIdentityCredentials",
+                "UpboundTokens",
+                "AWSWebIdentityCredentials"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "credentials"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "A ProviderConfigStatus reflects the observed state of a ProviderConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "users": {
+          "description": "Users of this provider configuration.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
  - I used this repository's `Utilities/openapi2jsonschema.py` converter directly against the official, versioned CRD manifests.
- [ ] I am updating existing schemas and have specified the updated schema version.
  - Not applicable: both schemas are new.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
  - [provider-kubernetes v1.1.0](https://github.com/crossplane-contrib/provider-kubernetes/tree/v1.1.0)
  - [provider-keycloak v3.0.1](https://github.com/crossplane-contrib/provider-keycloak/tree/v3.0.1)

## Validation

Validated real `ProviderConfig` manifests for both API groups with `kubeconform -strict` using the new catalog paths.
