### PR TITLE
feat: update mariadb-operator to 26.6.0

### DIFF
--- a/k8s.mariadb.com/backup_v1alpha1.json
+++ b/k8s.mariadb.com/backup_v1alpha1.json
@@ -23,18 +23,18 @@
               "type": "boolean"
             },
             "nodeAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                     "properties": {
                       "preference": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -63,7 +63,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -110,15 +110,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                   "properties": {
                     "nodeSelectorTerms": {
                       "items": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -147,7 +147,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -193,21 +193,21 @@
               "additionalProperties": false
             },
             "podAntiAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                     "properties": {
                       "podAffinityTerm": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                         "properties": {
                           "labelSelector": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                             "properties": {
                               "matchExpressions": {
                                 "items": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                   "properties": {
                                     "key": {
                                       "type": "string"
@@ -271,14 +271,14 @@
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                     "properties": {
                       "labelSelector": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -377,7 +377,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -809,7 +809,7 @@
               "description": "Volume is a Kubernetes volume specification.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -818,7 +818,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -845,7 +845,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -868,7 +868,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -884,7 +884,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -904,7 +904,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"
@@ -1175,7 +1175,7 @@
               "description": "Volume is a Kubernetes volume specification.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -1184,7 +1184,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -1211,7 +1211,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -1234,7 +1234,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -1250,7 +1250,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -1270,7 +1270,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"

--- a/k8s.mariadb.com/externalmariadb_v1alpha1.json
+++ b/k8s.mariadb.com/externalmariadb_v1alpha1.json
@@ -133,7 +133,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -208,15 +208,15 @@
               "description": "ClientCertIssuerRef is a reference to a cert-manager issuer object used to issue the client certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with clientCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via clientCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },
@@ -264,19 +264,26 @@
               "type": "object",
               "additionalProperties": false
             },
+            "serverCertAdditionalNames": {
+              "description": "ServerCertAdditionalNames is a list of additional certificate common names",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "serverCertIssuerRef": {
               "description": "ServerCertIssuerRef is a reference to a cert-manager issuer object used to issue the server certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with serverCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via serverCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },

--- a/k8s.mariadb.com/mariadb_v1alpha1.json
+++ b/k8s.mariadb.com/mariadb_v1alpha1.json
@@ -23,18 +23,18 @@
               "type": "boolean"
             },
             "nodeAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                     "properties": {
                       "preference": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -63,7 +63,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -110,15 +110,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                   "properties": {
                     "nodeSelectorTerms": {
                       "items": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -147,7 +147,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -193,21 +193,21 @@
               "additionalProperties": false
             },
             "podAntiAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                     "properties": {
                       "podAffinityTerm": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                         "properties": {
                           "labelSelector": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                             "properties": {
                               "matchExpressions": {
                                 "items": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                   "properties": {
                                     "key": {
                                       "type": "string"
@@ -271,14 +271,14 @@
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                     "properties": {
                       "labelSelector": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -346,6 +346,80 @@
         "bootstrapFrom": {
           "description": "BootstrapFrom defines a source to bootstrap from.",
           "properties": {
+            "azureBlob": {
+              "description": "AzureBlob defines the configuration to restore from Azure Blob compatible storage.\nThis field takes precedence over the Volume source.",
+              "properties": {
+                "containerName": {
+                  "description": "ContainerName is the name of the storage container.",
+                  "type": "string"
+                },
+                "prefix": {
+                  "description": "Prefix indicates a folder/subfolder in the container. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+                  "type": "string"
+                },
+                "serviceURL": {
+                  "description": "ServiceURL is the full URL for connecting to Azure, usually in the form: http(s)://<account>.blob.core.windows.net/.",
+                  "type": "string"
+                },
+                "storageAccountKey": {
+                  "description": "StorageAccountKey is a reference to a Secret key containing the Azure Blob Storage Storage account Key. Pairs with StorageAccountKey for static credential authentication",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageAccountName": {
+                  "description": "StorageAccountName is the name of the storage account. Pairs with StorageAccountKey for static credential authentication",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "TLS provides the configuration required to establish TLS connections with Azure Blob Storage.",
+                  "properties": {
+                    "caSecretKeyRef": {
+                      "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enabled is a flag to enable TLS.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "containerName",
+                "serviceURL"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "backupContentType": {
               "description": "BackupContentType is the backup content type available in the source to bootstrap from.\nIt is inferred based on the BackupRef and VolumeSnapshotRef fields. If inference is not possible, it defaults to Logical.\nSet this field explicitly when using physical backups from S3 or Volume sources.",
               "enum": [
@@ -369,8 +443,33 @@
               "type": "object",
               "additionalProperties": false
             },
+            "logLevel": {
+              "default": "info",
+              "description": "LogLevel to be used in the mariadb-operator container of the restoration Job. It defaults to 'info'.",
+              "enum": [
+                "debug",
+                "info",
+                "warn",
+                "error",
+                "dpanic",
+                "panic",
+                "fatal"
+              ],
+              "type": "string"
+            },
+            "pointInTimeRecoveryRef": {
+              "description": "PointInTimeRecoveryRef is a reference to a PointInTimeRecovery object.\nProviding this field implies restoring the PhysicalBackup referenced in the PointInTimeRecovery object and replaying the\narchived binary logs up to the point-in-time restoration target, defined by the targetRecoveryTime field.",
+              "properties": {
+                "name": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "restoreJob": {
-              "description": "RestoreJob defines additional properties for the Job used to perform the restoration.",
+              "description": "RestoreJob defines additional properties for the restoration Job.",
               "properties": {
                 "affinity": {
                   "description": "Affinity to be used in the Pod.",
@@ -380,18 +479,18 @@
                       "type": "boolean"
                     },
                     "nodeAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                             "properties": {
                               "preference": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -420,7 +519,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -467,15 +566,15 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                           "properties": {
                             "nodeSelectorTerms": {
                               "items": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -504,7 +603,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -550,21 +649,21 @@
                       "additionalProperties": false
                     },
                     "podAntiAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                             "properties": {
                               "podAffinityTerm": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                     "properties": {
                                       "matchExpressions": {
                                         "items": {
-                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                           "properties": {
                                             "key": {
                                               "type": "string"
@@ -628,14 +727,14 @@
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                             "properties": {
                               "labelSelector": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -942,7 +1041,7 @@
               "additionalProperties": false
             },
             "stagingStorage": {
-              "description": "StagingStorage defines the temporary storage used to keep external backups (i.e. S3) while they are being processed.\nIt defaults to an emptyDir volume, meaning that the backups will be temporarily stored in the node where the Job is scheduled.",
+              "description": "StagingStorage defines the temporary storage used to keep external backups and binary logs (i.e. S3) while they are being processed.\nIt defaults to an emptyDir volume, meaning that the backups will be temporarily stored in the node where the Job is scheduled.",
               "properties": {
                 "persistentVolumeClaim": {
                   "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
@@ -1051,7 +1150,7 @@
                   "description": "Volume is a Kubernetes volume specification.",
                   "properties": {
                     "csi": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                       "properties": {
                         "driver": {
                           "type": "string"
@@ -1060,7 +1159,7 @@
                           "type": "string"
                         },
                         "nodePublishSecretRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                           "properties": {
                             "name": {
                               "default": "",
@@ -1087,7 +1186,7 @@
                       "additionalProperties": false
                     },
                     "emptyDir": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                       "properties": {
                         "medium": {
                           "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -1110,7 +1209,7 @@
                       "additionalProperties": false
                     },
                     "hostPath": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                       "properties": {
                         "path": {
                           "type": "string"
@@ -1126,7 +1225,7 @@
                       "additionalProperties": false
                     },
                     "nfs": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                       "properties": {
                         "path": {
                           "type": "string"
@@ -1146,7 +1245,7 @@
                       "additionalProperties": false
                     },
                     "persistentVolumeClaim": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                       "properties": {
                         "claimName": {
                           "type": "string"
@@ -1178,7 +1277,7 @@
               "description": "Volume is a Kubernetes Volume object that contains a backup.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -1187,7 +1286,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -1214,7 +1313,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -1237,7 +1336,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -1253,7 +1352,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -1273,7 +1372,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"
@@ -1306,6 +1405,14 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "cleanupPolicy": {
+          "description": "CleanupPolicy defines the behavior for cleaning up the initial User, Database, and Grant created by the operator.",
+          "enum": [
+            "Skip",
+            "Delete"
+          ],
+          "type": "string"
         },
         "command": {
           "description": "Command to be used in the Container.",
@@ -1416,10 +1523,14 @@
           "description": "Database is the name of the initial Database.",
           "type": "string"
         },
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks to be used in the Pod.",
+          "type": "boolean"
+        },
         "env": {
           "description": "Env represents the environment variables to be injected in a container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
             "properties": {
               "name": {
                 "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -1429,10 +1540,10 @@
                 "type": "string"
               },
               "valueFrom": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                 "properties": {
                   "configMapKeyRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -1450,7 +1561,7 @@
                     "additionalProperties": false
                   },
                   "fieldRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                     "properties": {
                       "apiVersion": {
                         "type": "string"
@@ -1467,7 +1578,7 @@
                     "additionalProperties": false
                   },
                   "secretKeyRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -1500,10 +1611,10 @@
         "envFrom": {
           "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
             "properties": {
               "configMapRef": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                 "properties": {
                   "name": {
                     "default": "",
@@ -1517,7 +1628,7 @@
                 "type": "string"
               },
               "secretRef": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                 "properties": {
                   "name": {
                     "default": "",
@@ -1594,7 +1705,7 @@
                 "env": {
                   "description": "Env represents the environment variables to be injected in a container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                     "properties": {
                       "name": {
                         "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -1604,10 +1715,10 @@
                         "type": "string"
                       },
                       "valueFrom": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                         "properties": {
                           "configMapKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -1625,7 +1736,7 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                             "properties": {
                               "apiVersion": {
                                 "type": "string"
@@ -1642,7 +1753,7 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -1675,10 +1786,10 @@
                 "envFrom": {
                   "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
                     "properties": {
                       "configMapRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -1692,7 +1803,7 @@
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -1740,11 +1851,144 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "lifecycle": {
+                  "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+                  "properties": {
+                    "postStart": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "livenessProbe": {
                   "description": "LivenessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -1762,7 +2006,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -1805,7 +2049,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -1850,7 +2094,7 @@
                   "description": "ReadinessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -1868,7 +2112,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -1911,7 +2155,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2037,7 +2281,7 @@
                   "description": "StartupProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -2055,7 +2299,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2098,7 +2342,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2132,7 +2376,7 @@
                 "volumeMounts": {
                   "description": "VolumeMounts to be used in the Container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                     "properties": {
                       "mountPath": {
                         "type": "string"
@@ -2308,6 +2552,10 @@
               "description": "GaleraLibPath is a path inside the MariaDB image to the wsrep provider plugin. It is defaulted if not provided.\nMore info: https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-provider.",
               "type": "string"
             },
+            "gtidDomainId": {
+              "description": "GtidDomainID is the domain ID to be used in GTID mode, enabled when the multi-cluster topology is used.\nFor example: if you set this to `0`, the 'wsrep_gtid_domain_id' will be 0, while the replicas (if 3) will have 'gtid_domain_id' 1,2,3.\nMake sure it has a different value on each the member of a multi-cluster topology.\nSee: https://mariadb.com/docs/galera-cluster/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/configuring-mariadb-replication-between-two-mariadb-galera-clusters",
+              "type": "integer"
+            },
             "initContainer": {
               "description": "InitContainer is an init container that runs in the MariaDB Pod and co-operates with mariadb-operator.",
               "properties": {
@@ -2328,7 +2576,7 @@
                 "env": {
                   "description": "Env represents the environment variables to be injected in a container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                     "properties": {
                       "name": {
                         "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -2338,10 +2586,10 @@
                         "type": "string"
                       },
                       "valueFrom": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                         "properties": {
                           "configMapKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -2359,7 +2607,7 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                             "properties": {
                               "apiVersion": {
                                 "type": "string"
@@ -2376,7 +2624,7 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -2409,10 +2657,10 @@
                 "envFrom": {
                   "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
                     "properties": {
                       "configMapRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -2426,7 +2674,7 @@
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -2455,11 +2703,144 @@
                   ],
                   "type": "string"
                 },
+                "lifecycle": {
+                  "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+                  "properties": {
+                    "postStart": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "livenessProbe": {
                   "description": "LivenessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -2477,7 +2858,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2520,7 +2901,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2555,7 +2936,7 @@
                   "description": "ReadinessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -2573,7 +2954,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2616,7 +2997,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2742,7 +3123,7 @@
                   "description": "StartupProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -2760,7 +3141,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2803,7 +3184,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -2837,7 +3218,7 @@
                 "volumeMounts": {
                   "description": "VolumeMounts to be used in the Container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                     "properties": {
                       "mountPath": {
                         "type": "string"
@@ -3069,7 +3450,7 @@
                       "type": "string"
                     }
                   ],
-                  "description": "MinClusterSize is the minimum number of replicas to consider the cluster healthy. It can be either a number of replicas (1) or a percentage (50%).\nIf Galera consistently reports less replicas than this value for the given 'ClusterHealthyTimeout' interval, a cluster recovery is initiated.\nIt defaults to '1' replica, and it is highly recommendeded to keep this value at '1' in most cases.\nIf set to more than one replica, the cluster recovery process may restart the healthy replicas as well.",
+                  "description": "MinClusterSize is the minimum number of replicas to consider the cluster healthy. It can be either a number of replicas (1) or a percentage (50%).\nIf Galera consistently reports less replicas than this value for the given 'ClusterHealthyTimeout' interval, a cluster recovery is initiated.\nIt defaults to '1' replica, and it is highly recommended to keep this value at '1' in most cases.\nIf set to more than one replica, the cluster recovery process may restart the healthy replicas as well.",
                   "x-kubernetes-int-or-string": true
                 },
                 "podRecoveryTimeout": {
@@ -3084,8 +3465,35 @@
               "type": "object",
               "additionalProperties": false
             },
+            "replPasswordSecretKeyRef": {
+              "description": "ReplPasswordSecretKeyRef provides a reference to the Secret to use as password for the replication user.\nThis will be utilized as password of the replication user, when the multi-cluster topology is enabled.\nBy default, a random password will be generated.",
+              "properties": {
+                "generate": {
+                  "default": false,
+                  "description": "Generate indicates whether the Secret should be generated if the Secret referenced is not present.",
+                  "type": "boolean"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
             "replicaThreads": {
               "description": "ReplicaThreads is the number of replica threads used to apply Galera write sets in parallel.\nMore info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_threads.",
+              "type": "integer"
+            },
+            "serverId": {
+              "description": "ServerID is the server ID to be used in GTID mode, enabled when the multi-cluster topology is used.\nMake sure it has a different value on each the member of a multi-cluster topology.\nSee: https://mariadb.com/docs/galera-cluster/high-availability/using-mariadb-replication-with-mariadb-galera-cluster/configuring-mariadb-replication-between-two-mariadb-galera-clusters",
               "type": "integer"
             },
             "sst": {
@@ -3117,7 +3525,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -3172,7 +3580,7 @@
               "env": {
                 "description": "Env represents the environment variables to be injected in a container.",
                 "items": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                   "properties": {
                     "name": {
                       "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -3182,10 +3590,10 @@
                       "type": "string"
                     },
                     "valueFrom": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                       "properties": {
                         "configMapKeyRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                           "properties": {
                             "key": {
                               "type": "string"
@@ -3203,7 +3611,7 @@
                           "additionalProperties": false
                         },
                         "fieldRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                           "properties": {
                             "apiVersion": {
                               "type": "string"
@@ -3220,7 +3628,7 @@
                           "additionalProperties": false
                         },
                         "secretKeyRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                           "properties": {
                             "key": {
                               "type": "string"
@@ -3309,7 +3717,7 @@
               "volumeMounts": {
                 "description": "VolumeMounts to be used in the Container.",
                 "items": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                   "properties": {
                     "mountPath": {
                       "type": "string"
@@ -3343,11 +3751,144 @@
           },
           "type": "array"
         },
+        "lifecycle": {
+          "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+          "properties": {
+            "postStart": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+              "properties": {
+                "exec": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sleep": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                  "properties": {
+                    "seconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "preStop": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+              "properties": {
+                "exec": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sleep": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                  "properties": {
+                    "seconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "livenessProbe": {
           "description": "LivenessProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -3365,7 +3906,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -3408,7 +3949,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -3439,8 +3980,36 @@
           "type": "object",
           "additionalProperties": false
         },
+        "maintenance": {
+          "description": "Maintenance defines different capabilities of the operator to allow for maintenance to be performed on the DB.\nNot to be confused with `suspend`, maintenance does not interfere with the normal reconciliation of the operator.",
+          "properties": {
+            "cordon": {
+              "description": "Cordon blocks connections to the resource.",
+              "type": "boolean"
+            },
+            "drainConnections": {
+              "description": "DrainConnections determines whether all connections in MariaDB should be drained after `drainGracePeriodSeconds`.",
+              "type": "boolean"
+            },
+            "drainGracePeriodSeconds": {
+              "default": 30,
+              "description": "DrainGracePeriodSeconds defines the grace period in seconds before a connection in MariaDB is drained.",
+              "type": "integer"
+            },
+            "enabled": {
+              "description": "Enabled turns on maintenance mode",
+              "type": "boolean"
+            },
+            "readOnly": {
+              "description": "ReadOnly will allow only read statements to be performed on the resource.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "maxScaleRef": {
-          "description": "MaxScaleRef is a reference to a MaxScale resource to be used with the current MariaDB.\nProviding this field implies delegating high availability tasks such as primary failover to MaxScale.",
+          "description": "MaxScaleRef is a reference to a MaxScale resource to be used with the current MariaDB.\nProviding this reference implies delegating high availability tasks such as primary failover to MaxScale.",
           "properties": {
             "name": {
               "type": "string"
@@ -3470,18 +4039,18 @@
                       "type": "boolean"
                     },
                     "nodeAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                             "properties": {
                               "preference": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -3510,7 +4079,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -3557,15 +4126,15 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                           "properties": {
                             "nodeSelectorTerms": {
                               "items": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -3594,7 +4163,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -3640,21 +4209,21 @@
                       "additionalProperties": false
                     },
                     "podAntiAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                             "properties": {
                               "podAffinityTerm": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                     "properties": {
                                       "matchExpressions": {
                                         "items": {
-                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                           "properties": {
                                             "key": {
                                               "type": "string"
@@ -3718,14 +4287,14 @@
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                             "properties": {
                               "labelSelector": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -3806,7 +4375,7 @@
                 "imagePullSecrets": {
                   "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                     "properties": {
                       "name": {
                         "default": "",
@@ -4129,6 +4698,52 @@
           "type": "object",
           "additionalProperties": false
         },
+        "multiCluster": {
+          "description": "MultiCluster configures the multi-cluster topology.",
+          "properties": {
+            "enabled": {
+              "description": "Enabled is a flag to enable the multi-cluster topology.",
+              "type": "boolean"
+            },
+            "members": {
+              "description": "Members is the specification of each member of the multi-cluster topology.",
+              "items": {
+                "description": "MultiClusterMember defines the configuration for a multi-cluster topology member.",
+                "properties": {
+                  "externalMariaDbRef": {
+                    "description": "ExternalMariaDBRef holds a reference to an ExternalMariaDB with connection details to form the multi-cluster topology.\nThese connection details are utilized to setup remote replicas.",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name is the identifier of the member.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "primary": {
+              "description": "Primary is the name of the primary cluster. It refers to a member in the 'members' field, containing its full specification.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "myCnf": {
           "description": "MyCnf allows to specify the my.cnf file mounted by Mariadb.\nUpdating this field will trigger an update to the Mariadb resource.",
           "type": "string"
@@ -4387,6 +5002,17 @@
           "type": "object",
           "additionalProperties": false
         },
+        "pointInTimeRecoveryRef": {
+          "description": "PointInTimeRecoveryRef is a reference to a PointInTimeRecovery resource to be used with the current MariaDB.\nProviding this reference implies configuring binary logs in the MariaDB instance and binary log archival in the sidecar agent.",
+          "properties": {
+            "name": {
+              "default": "",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "port": {
           "default": 3306,
           "description": "Port where the instances will be listening for connections.",
@@ -4502,6 +5128,10 @@
               "description": "ExternalTrafficPolicy Service field.",
               "type": "string"
             },
+            "loadBalancerClass": {
+              "description": "LoadBalancerClass Service field.",
+              "type": "string"
+            },
             "loadBalancerIP": {
               "description": "LoadBalancerIP Service field.",
               "type": "string"
@@ -4560,7 +5190,7 @@
           "description": "ReadinessProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -4578,7 +5208,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -4621,7 +5251,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -4724,7 +5354,7 @@
                 "env": {
                   "description": "Env represents the environment variables to be injected in a container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                     "properties": {
                       "name": {
                         "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -4734,10 +5364,10 @@
                         "type": "string"
                       },
                       "valueFrom": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                         "properties": {
                           "configMapKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -4755,7 +5385,7 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                             "properties": {
                               "apiVersion": {
                                 "type": "string"
@@ -4772,7 +5402,7 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -4805,10 +5435,10 @@
                 "envFrom": {
                   "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
                     "properties": {
                       "configMapRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -4822,7 +5452,7 @@
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -4870,11 +5500,144 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "lifecycle": {
+                  "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+                  "properties": {
+                    "postStart": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "livenessProbe": {
                   "description": "LivenessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -4892,7 +5655,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -4935,7 +5698,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -4980,7 +5743,7 @@
                   "description": "ReadinessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -4998,7 +5761,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5041,7 +5804,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5167,7 +5930,7 @@
                   "description": "StartupProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -5185,7 +5948,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5228,7 +5991,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5262,7 +6025,7 @@
                 "volumeMounts": {
                   "description": "VolumeMounts to be used in the Container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                     "properties": {
                       "mountPath": {
                         "type": "string"
@@ -5295,6 +6058,10 @@
               "description": "Enabled is a flag to enable replication.",
               "type": "boolean"
             },
+            "gtidDomainId": {
+              "description": "GtidDomainID is gtid_domain_id for all of the MariaDB nodes.\nIt is immutable.\nSee: https://mariadb.com/docs/server/ha-and-performance/standard-replication/gtid#gtid_domain_id",
+              "type": "integer"
+            },
             "gtidStrictMode": {
               "description": "GtidStrictMode determines whether the GTID strict mode is enabled.\nSee: https://mariadb.com/docs/server/ha-and-performance/standard-replication/gtid#gtid_strict_mode.\nIt is enabled by default.",
               "type": "boolean"
@@ -5319,7 +6086,7 @@
                 "env": {
                   "description": "Env represents the environment variables to be injected in a container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                     "properties": {
                       "name": {
                         "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -5329,10 +6096,10 @@
                         "type": "string"
                       },
                       "valueFrom": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                         "properties": {
                           "configMapKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -5350,7 +6117,7 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                             "properties": {
                               "apiVersion": {
                                 "type": "string"
@@ -5367,7 +6134,7 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                             "properties": {
                               "key": {
                                 "type": "string"
@@ -5400,10 +6167,10 @@
                 "envFrom": {
                   "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
                     "properties": {
                       "configMapRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -5417,7 +6184,7 @@
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                         "properties": {
                           "name": {
                             "default": "",
@@ -5446,11 +6213,144 @@
                   ],
                   "type": "string"
                 },
+                "lifecycle": {
+                  "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+                  "properties": {
+                    "postStart": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+                      "properties": {
+                        "exec": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                          "properties": {
+                            "seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "livenessProbe": {
                   "description": "LivenessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -5468,7 +6368,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5511,7 +6411,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5546,7 +6446,7 @@
                   "description": "ReadinessProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -5564,7 +6464,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5607,7 +6507,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5733,7 +6633,7 @@
                   "description": "StartupProbe to be used in the Container.",
                   "properties": {
                     "exec": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
                       "properties": {
                         "command": {
                           "items": {
@@ -5751,7 +6651,7 @@
                       "type": "integer"
                     },
                     "httpGet": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5794,7 +6694,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
                       "properties": {
                         "host": {
                           "type": "string"
@@ -5828,7 +6728,7 @@
                 "volumeMounts": {
                   "description": "VolumeMounts to be used in the Container.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                     "properties": {
                       "mountPath": {
                         "type": "string"
@@ -5907,18 +6807,18 @@
                               "type": "boolean"
                             },
                             "nodeAffinity": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
                               "properties": {
                                 "preferredDuringSchedulingIgnoredDuringExecution": {
                                   "items": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                                     "properties": {
                                       "preference": {
-                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                         "properties": {
                                           "matchExpressions": {
                                             "items": {
-                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                               "properties": {
                                                 "key": {
                                                   "type": "string"
@@ -5947,7 +6847,7 @@
                                           },
                                           "matchFields": {
                                             "items": {
-                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                               "properties": {
                                                 "key": {
                                                   "type": "string"
@@ -5994,15 +6894,15 @@
                                   "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                                   "properties": {
                                     "nodeSelectorTerms": {
                                       "items": {
-                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                         "properties": {
                                           "matchExpressions": {
                                             "items": {
-                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                               "properties": {
                                                 "key": {
                                                   "type": "string"
@@ -6031,7 +6931,7 @@
                                           },
                                           "matchFields": {
                                             "items": {
-                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                               "properties": {
                                                 "key": {
                                                   "type": "string"
@@ -6077,21 +6977,21 @@
                               "additionalProperties": false
                             },
                             "podAntiAffinity": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
                               "properties": {
                                 "preferredDuringSchedulingIgnoredDuringExecution": {
                                   "items": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                                     "properties": {
                                       "podAffinityTerm": {
-                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                                         "properties": {
                                           "labelSelector": {
-                                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                             "properties": {
                                               "matchExpressions": {
                                                 "items": {
-                                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                                   "properties": {
                                                     "key": {
                                                       "type": "string"
@@ -6155,14 +7055,14 @@
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "items": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                                     "properties": {
                                       "labelSelector": {
-                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                         "properties": {
                                           "matchExpressions": {
                                             "items": {
-                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                               "properties": {
                                                 "key": {
                                                   "type": "string"
@@ -6418,6 +7318,10 @@
               ],
               "type": "string"
             },
+            "serverIdStartIndex": {
+              "description": "ServerIDStartIndex sets the start index of the MariaDB nodes. Each subsequent replica will increment this by 1.\nIt is immutable.\nSee: https://mariadb.com/docs/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#server_id",
+              "type": "integer"
+            },
             "standaloneProbes": {
               "description": "StandaloneProbes indicates whether to use the default non-HA startup and liveness probes.\nIt is disabled by default",
               "type": "boolean"
@@ -6605,6 +7509,10 @@
               "description": "ExternalTrafficPolicy Service field.",
               "type": "string"
             },
+            "loadBalancerClass": {
+              "description": "LoadBalancerClass Service field.",
+              "type": "string"
+            },
             "loadBalancerIP": {
               "description": "LoadBalancerIP Service field.",
               "type": "string"
@@ -6718,6 +7626,10 @@
               "description": "ExternalTrafficPolicy Service field.",
               "type": "string"
             },
+            "loadBalancerClass": {
+              "description": "LoadBalancerClass Service field.",
+              "type": "string"
+            },
             "loadBalancerIP": {
               "description": "LoadBalancerIP Service field.",
               "type": "string"
@@ -6775,7 +7687,7 @@
         "servicePorts": {
           "description": "ServicePorts is the list of additional named ports to be added to the Services created by the operator.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#serviceport-v1-core",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#serviceport-v1-core",
             "properties": {
               "name": {
                 "type": "string"
@@ -6816,7 +7728,7 @@
               "env": {
                 "description": "Env represents the environment variables to be injected in a container.",
                 "items": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                   "properties": {
                     "name": {
                       "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -6826,10 +7738,10 @@
                       "type": "string"
                     },
                     "valueFrom": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                       "properties": {
                         "configMapKeyRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                           "properties": {
                             "key": {
                               "type": "string"
@@ -6847,7 +7759,7 @@
                           "additionalProperties": false
                         },
                         "fieldRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                           "properties": {
                             "apiVersion": {
                               "type": "string"
@@ -6864,7 +7776,7 @@
                           "additionalProperties": false
                         },
                         "secretKeyRef": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                           "properties": {
                             "key": {
                               "type": "string"
@@ -6953,7 +7865,7 @@
               "volumeMounts": {
                 "description": "VolumeMounts to be used in the Container.",
                 "items": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
                   "properties": {
                     "mountPath": {
                       "type": "string"
@@ -6991,7 +7903,7 @@
           "description": "StartupProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -7009,7 +7921,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -7052,7 +7964,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -7089,6 +8001,21 @@
             "ephemeral": {
               "description": "Ephemeral indicates whether to use ephemeral storage in the PVCs. It is only compatible with non HA MariaDBs.",
               "type": "boolean"
+            },
+            "pvcRetentionPolicy": {
+              "description": "PersistentVolumeClaimRetentionPolicy describes the lifecycle of PVCs created from volumeClaimTemplates.\nBy default, all persistent volume claims are created as needed and retained until manually deleted.\nThis policy allows the lifecycle to be altered, for example by deleting PVCs when their statefulset is deleted,\nor when their pod is scaled down.",
+              "properties": {
+                "whenDeleted": {
+                  "description": "PersistentVolumeClaimRetentionPolicyType describes the lifecycle of persistent volume claims.\nRefer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps.",
+                  "type": "string"
+                },
+                "whenScaled": {
+                  "description": "PersistentVolumeClaimRetentionPolicyType describes the lifecycle of persistent volume claims.\nRefer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "resizeInUseVolumes": {
               "description": "ResizeInUseVolumes indicates whether the PVCs can be resized. The 'StorageClassName' used should have 'allowVolumeExpansion' set to 'true' to allow resizing.\nIt defaults to true.",
@@ -7248,6 +8175,11 @@
           "description": "Suspend indicates whether the current resource should be suspended or not.\nThis can be useful for maintenance, as disabling the reconciliation prevents the operator from interfering with user operations during maintenance activities.",
           "type": "boolean"
         },
+        "terminationGracePeriodSeconds": {
+          "description": "TerminationGracePeriodSeconds to be used in the Pod.",
+          "format": "int64",
+          "type": "integer"
+        },
         "timeZone": {
           "description": "TimeZone sets the default timezone. If not provided, it defaults to SYSTEM and the timezone data is not loaded.",
           "type": "string"
@@ -7270,15 +8202,15 @@
               "description": "ClientCertIssuerRef is a reference to a cert-manager issuer object used to issue the client certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with clientCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via clientCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },
@@ -7322,19 +8254,26 @@
               "type": "object",
               "additionalProperties": false
             },
+            "serverCertAdditionalNames": {
+              "description": "ServerCertAdditionalNames is a list of additional certificate common names",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "serverCertIssuerRef": {
               "description": "ServerCertIssuerRef is a reference to a cert-manager issuer object used to issue the server certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with serverCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via serverCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },
@@ -7394,7 +8333,7 @@
         "topologySpreadConstraints": {
           "description": "TopologySpreadConstraints to be used in the Pod.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#topologyspreadconstraint-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#topologyspreadconstraint-v1-core.",
             "properties": {
               "labelSelector": {
                 "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
@@ -7535,7 +8474,7 @@
         "volumeMounts": {
           "description": "VolumeMounts to be used in the Container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
             "properties": {
               "mountPath": {
                 "type": "string"
@@ -7563,10 +8502,10 @@
         "volumes": {
           "description": "Volumes to be used in the Pod.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volume-v1-core.",
             "properties": {
               "configMap": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapvolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapvolumesource-v1-core.",
                 "properties": {
                   "defaultMode": {
                     "format": "int32",
@@ -7581,7 +8520,7 @@
                 "additionalProperties": false
               },
               "csi": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                 "properties": {
                   "driver": {
                     "type": "string"
@@ -7590,7 +8529,7 @@
                     "type": "string"
                   },
                   "nodePublishSecretRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                     "properties": {
                       "name": {
                         "default": "",
@@ -7617,7 +8556,7 @@
                 "additionalProperties": false
               },
               "emptyDir": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                 "properties": {
                   "medium": {
                     "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -7639,8 +8578,139 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "ephemeral": {
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#ephemeralvolumesource-v1-core.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "VolumeClaimTemplate defines a template to customize PVC objects.",
+                    "properties": {
+                      "accessModes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "metadata": {
+                        "description": "Metadata to be added to the PVC metadata.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations to be added to children resources.",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Labels to be added to children resources.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "selector": {
+                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "storageClassName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "hostPath": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                 "properties": {
                   "path": {
                     "type": "string"
@@ -7659,7 +8729,7 @@
                 "type": "string"
               },
               "nfs": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                 "properties": {
                   "path": {
                     "type": "string"
@@ -7679,7 +8749,7 @@
                 "additionalProperties": false
               },
               "persistentVolumeClaim": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                 "properties": {
                   "claimName": {
                     "type": "string"
@@ -7695,7 +8765,7 @@
                 "additionalProperties": false
               },
               "secret": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretvolumesource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretvolumesource-v1-core.",
                 "properties": {
                   "defaultMode": {
                     "format": "int32",
@@ -7785,6 +8855,10 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "currentMultiClusterPrimary": {
+          "description": "CurrentMultiClusterPrimary is the current primary cluster name when using the multi-cluster topology.",
+          "type": "string"
         },
         "currentPrimary": {
           "description": "CurrentPrimary is the primary Pod.",
@@ -7876,6 +8950,40 @@
           "type": "object",
           "additionalProperties": false
         },
+        "pointInTimeRecovery": {
+          "description": "PointInTimeRecovery is the status of the point-in-time-recovery process.",
+          "properties": {
+            "lastArchivedBinaryLog": {
+              "description": "LastArchivedBinaryLog is name of the last archived binary log.",
+              "type": "string"
+            },
+            "lastArchivedGtid": {
+              "description": "LastArchivedGtid is the last archived GTID.",
+              "type": "string"
+            },
+            "lastArchivedPosition": {
+              "description": "LastArchivedPosition is the position of last archived binary log event.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "lastArchivedTime": {
+              "description": "LastArchivedTime is the time of the last archived binary log event.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "serverId": {
+              "description": "ServerId identifies the server whose binary logs are being archived.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "storageReadyForArchival": {
+              "description": "StorageReadyForArchival indicates that the storage is ready for archival, meaning that the sidecar agent can start archiving the binary logs.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "replicas": {
           "description": "Replicas indicates the number of current instances.",
           "format": "int32",
@@ -7884,6 +8992,10 @@
         "replication": {
           "description": "Replication is the replication current status per each Pod.",
           "properties": {
+            "gtidStrictModePaused": {
+              "description": "GtidStrictModePaused indicates that gtid_strict_mode has been temporarily paused.",
+              "type": "boolean"
+            },
             "replicaToRecover": {
               "description": "ReplicaToRecover is the replica that is being recovered by the operator.",
               "type": "string"
@@ -7932,6 +9044,10 @@
                   "slaveSQLRunning": {
                     "description": "SlaveSQLRunning indicates whether the slave SQL thread is running.",
                     "type": "boolean"
+                  },
+                  "usingGtid": {
+                    "description": "UsingGtid is the GTID position mode (Slave_Pos or Current_Pos)",
+                    "type": "string"
                   }
                 },
                 "type": "object",
@@ -7951,6 +9067,10 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "rootPasswordHash": {
+          "description": "RootPasswordHash is a hash of the root password. It is used to avoid unnecessary reconciliations.",
+          "type": "string"
         },
         "scaleOutInitialIndex": {
           "description": "ScaleOutInitialIndex is the initial index where the scale out operation started.",

--- a/k8s.mariadb.com/maxscale_v1alpha1.json
+++ b/k8s.mariadb.com/maxscale_v1alpha1.json
@@ -39,18 +39,18 @@
               "type": "boolean"
             },
             "nodeAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                     "properties": {
                       "preference": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -79,7 +79,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -126,15 +126,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                   "properties": {
                     "nodeSelectorTerms": {
                       "items": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -163,7 +163,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -209,21 +209,21 @@
               "additionalProperties": false
             },
             "podAntiAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                     "properties": {
                       "podAffinityTerm": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                         "properties": {
                           "labelSelector": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                             "properties": {
                               "matchExpressions": {
                                 "items": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                   "properties": {
                                     "key": {
                                       "type": "string"
@@ -287,14 +287,14 @@
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                     "properties": {
                       "labelSelector": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -818,10 +818,14 @@
           "type": "object",
           "additionalProperties": false
         },
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links. Defaults to true if not specified.\nSet to false to disable injection of service link environment variables.",
+          "type": "boolean"
+        },
         "env": {
           "description": "Env represents the environment variables to be injected in a container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
             "properties": {
               "name": {
                 "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
@@ -831,10 +835,10 @@
                 "type": "string"
               },
               "valueFrom": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvarsource-v1-core.",
                 "properties": {
                   "configMapKeyRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#configmapkeyselector-v1-core.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -852,7 +856,7 @@
                     "additionalProperties": false
                   },
                   "fieldRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectfieldselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectfieldselector-v1-core.",
                     "properties": {
                       "apiVersion": {
                         "type": "string"
@@ -869,7 +873,7 @@
                     "additionalProperties": false
                   },
                   "secretKeyRef": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#secretkeyselector-v1-core.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -902,10 +906,10 @@
         "envFrom": {
           "description": "EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envfromsource-v1-core.",
             "properties": {
               "configMapRef": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                 "properties": {
                   "name": {
                     "default": "",
@@ -919,7 +923,7 @@
                 "type": "string"
               },
               "secretRef": {
-                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                 "properties": {
                   "name": {
                     "default": "",
@@ -944,6 +948,10 @@
             },
             "externalTrafficPolicy": {
               "description": "ExternalTrafficPolicy Service field.",
+              "type": "string"
+            },
+            "loadBalancerClass": {
+              "description": "LoadBalancerClass Service field.",
               "type": "string"
             },
             "loadBalancerIP": {
@@ -1012,7 +1020,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -1054,6 +1062,10 @@
             },
             "externalTrafficPolicy": {
               "description": "ExternalTrafficPolicy Service field.",
+              "type": "string"
+            },
+            "loadBalancerClass": {
+              "description": "LoadBalancerClass Service field.",
               "type": "string"
             },
             "loadBalancerIP": {
@@ -1106,11 +1118,144 @@
           "type": "object",
           "additionalProperties": false
         },
+        "lifecycle": {
+          "description": "Lifecycle are actions that the management system should take in response to container lifecycle events.",
+          "properties": {
+            "postStart": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+              "properties": {
+                "exec": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sleep": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                  "properties": {
+                    "seconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "preStop": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#lifecyclehandler-v1-core.",
+              "properties": {
+                "exec": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sleep": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#sleepaction-v1-core",
+                  "properties": {
+                    "seconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "livenessProbe": {
           "description": "LivenessProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -1128,7 +1273,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -1171,7 +1316,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -1197,6 +1342,21 @@
             "timeoutSeconds": {
               "format": "int32",
               "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "maintenance": {
+          "description": "Maintenance defines different capabilities of the operator to allow for maintenance to be performed on the DB.\nNot to be confused with `suspend`, maintenance does not interfere with the normal reconciliation of the operator.",
+          "properties": {
+            "cordon": {
+              "description": "Cordon blocks connections to the resource.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled turns on maintenance mode",
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -1242,18 +1402,18 @@
                       "type": "boolean"
                     },
                     "nodeAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                             "properties": {
                               "preference": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -1282,7 +1442,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -1329,15 +1489,15 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
-                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                           "properties": {
                             "nodeSelectorTerms": {
                               "items": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -1366,7 +1526,7 @@
                                   },
                                   "matchFields": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -1412,21 +1572,21 @@
                       "additionalProperties": false
                     },
                     "podAntiAffinity": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                             "properties": {
                               "podAffinityTerm": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                     "properties": {
                                       "matchExpressions": {
                                         "items": {
-                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                           "properties": {
                                             "key": {
                                               "type": "string"
@@ -1490,14 +1650,14 @@
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                             "properties": {
                               "labelSelector": {
-                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                                 "properties": {
                                   "matchExpressions": {
                                     "items": {
-                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                       "properties": {
                                         "key": {
                                           "type": "string"
@@ -1578,7 +1738,7 @@
                 "imagePullSecrets": {
                   "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                     "properties": {
                       "name": {
                         "default": "",
@@ -2077,7 +2237,7 @@
           "description": "ReadinessProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -2095,7 +2255,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -2138,7 +2298,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -2396,7 +2556,7 @@
           "description": "StartupProbe to be used in the Container.",
           "properties": {
             "exec": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#execaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#execaction-v1-core.",
               "properties": {
                 "command": {
                   "items": {
@@ -2414,7 +2574,7 @@
               "type": "integer"
             },
             "httpGet": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#httpgetaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#httpgetaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -2457,7 +2617,7 @@
               "type": "integer"
             },
             "tcpSocket": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#tcpsocketaction-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#tcpsocketaction-v1-core.",
               "properties": {
                 "host": {
                   "type": "string"
@@ -2511,15 +2671,15 @@
               "description": "AdminCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's administrative REST API and GUI certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with adminCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via adminCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },
@@ -2559,15 +2719,15 @@
               "description": "ListenerCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's listeners certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with listenerCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via listenerCASecretRef.",
               "properties": {
                 "group": {
-                  "description": "Group of the resource being referred to.",
+                  "description": "Group of the issuer being referred to.\nDefaults to 'cert-manager.io'.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind of the resource being referred to.",
+                  "description": "Kind of the issuer being referred to.\nDefaults to 'Issuer'.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the resource being referred to.",
+                  "description": "Name of the issuer being referred to.",
                   "type": "string"
                 }
               },
@@ -2661,7 +2821,7 @@
         "topologySpreadConstraints": {
           "description": "TopologySpreadConstraints to be used in the Pod.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#topologyspreadconstraint-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#topologyspreadconstraint-v1-core.",
             "properties": {
               "labelSelector": {
                 "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
@@ -2787,7 +2947,7 @@
         "volumeMounts": {
           "description": "VolumeMounts to be used in the Container.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#volumemount-v1-core.",
             "properties": {
               "mountPath": {
                 "type": "string"

--- a/k8s.mariadb.com/physicalbackup_v1alpha1.json
+++ b/k8s.mariadb.com/physicalbackup_v1alpha1.json
@@ -36,10 +36,16 @@
           ],
           "type": "string"
         },
+        "failedJobsHistoryLimit": {
+          "description": "FailedJobsHistoryLimit defines the maximum number of failed Jobs to be displayed. It defaults to 5.",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -294,6 +300,10 @@
               "description": "Immediate indicates whether the first backup should be taken immediately after creating the PhysicalBackup.",
               "type": "boolean"
             },
+            "onDemand": {
+              "description": "OnDemand is an identifier used to trigger an on-demand backup.\nIf the identifier is different than the one tracked under status.lastScheduleOnDemand, a new physical backup will be triggered.",
+              "type": "string"
+            },
             "suspend": {
               "default": false,
               "description": "Suspend defines whether the schedule is active or not.",
@@ -469,7 +479,7 @@
               "description": "Volume is a Kubernetes volume specification.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -478,7 +488,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -505,7 +515,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -528,7 +538,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -544,7 +554,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -564,7 +574,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"
@@ -590,6 +600,80 @@
         "storage": {
           "description": "Storage defines the final storage for backups.",
           "properties": {
+            "azureBlob": {
+              "description": "AzureBlob defines the configuration to store backups in a AzureBlob compatible storage.",
+              "properties": {
+                "containerName": {
+                  "description": "ContainerName is the name of the storage container.",
+                  "type": "string"
+                },
+                "prefix": {
+                  "description": "Prefix indicates a folder/subfolder in the container. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+                  "type": "string"
+                },
+                "serviceURL": {
+                  "description": "ServiceURL is the full URL for connecting to Azure, usually in the form: http(s)://<account>.blob.core.windows.net/.",
+                  "type": "string"
+                },
+                "storageAccountKey": {
+                  "description": "StorageAccountKey is a reference to a Secret key containing the Azure Blob Storage Storage account Key. Pairs with StorageAccountKey for static credential authentication",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageAccountName": {
+                  "description": "StorageAccountName is the name of the storage account. Pairs with StorageAccountKey for static credential authentication",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "TLS provides the configuration required to establish TLS connections with Azure Blob Storage.",
+                  "properties": {
+                    "caSecretKeyRef": {
+                      "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enabled is a flag to enable TLS.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "containerName",
+                "serviceURL"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "persistentVolumeClaim": {
               "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
               "properties": {
@@ -835,7 +919,7 @@
               "description": "Volume is a Kubernetes volume specification.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -844,7 +928,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -871,7 +955,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -894,7 +978,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -910,7 +994,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -930,7 +1014,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"
@@ -1108,6 +1192,10 @@
         "lastScheduleCheckTime": {
           "description": "LastScheduleCheckTime is the last time that the schedule was checked.",
           "format": "date-time",
+          "type": "string"
+        },
+        "lastScheduleOnDemand": {
+          "description": "LastScheduleOnDemand is the last on-demand schedule identifier.",
           "type": "string"
         },
         "lastScheduleTime": {

--- a/k8s.mariadb.com/pointintimerecovery_v1alpha1.json
+++ b/k8s.mariadb.com/pointintimerecovery_v1alpha1.json
@@ -1,0 +1,287 @@
+{
+  "description": "PointInTimeRecovery is the Schema for the pointintimerecoveries API. It contains binlog archival and point-in-time restoration settings.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PointInTimeRecoverySpec defines the desired state of PointInTimeRecovery. It contains binlog archive and point-in-time restoration settings.",
+      "properties": {
+        "archiveTimeout": {
+          "default": "1h",
+          "description": "ArchiveTimeout defines the maximum duration for the binary log archival.\nIf this duration is exceeded, the sidecar agent will log an error and it will be retried in the next archive cycle.\nIt defaults to 1 hour.",
+          "type": "string"
+        },
+        "compression": {
+          "description": "Compression algorithm to be used for compressing the binary logs.\nThis field is immutable, it cannot be updated after creation.",
+          "enum": [
+            "none",
+            "bzip2",
+            "gzip"
+          ],
+          "type": "string"
+        },
+        "physicalBackupRef": {
+          "description": "PhysicalBackupRef is a reference to a PhysicalBackup object that will be used as base backup.",
+          "properties": {
+            "name": {
+              "default": "",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "storage": {
+          "description": "PointInTimeRecoveryStorage is the storage where the point in time recovery data will be stored",
+          "properties": {
+            "azureBlob": {
+              "description": "AzureBlob is the Azure Blob Storage where the binary logs will be kept.",
+              "properties": {
+                "containerName": {
+                  "description": "ContainerName is the name of the storage container.",
+                  "type": "string"
+                },
+                "prefix": {
+                  "description": "Prefix indicates a folder/subfolder in the container. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+                  "type": "string"
+                },
+                "serviceURL": {
+                  "description": "ServiceURL is the full URL for connecting to Azure, usually in the form: http(s)://<account>.blob.core.windows.net/.",
+                  "type": "string"
+                },
+                "storageAccountKey": {
+                  "description": "StorageAccountKey is a reference to a Secret key containing the Azure Blob Storage Storage account Key. Pairs with StorageAccountKey for static credential authentication",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageAccountName": {
+                  "description": "StorageAccountName is the name of the storage account. Pairs with StorageAccountKey for static credential authentication",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "TLS provides the configuration required to establish TLS connections with Azure Blob Storage.",
+                  "properties": {
+                    "caSecretKeyRef": {
+                      "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enabled is a flag to enable TLS.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "containerName",
+                "serviceURL"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "s3": {
+              "description": "S3 is the S3-compatible storage where the binary logs will be kept.",
+              "properties": {
+                "accessKeyIdSecretKeyRef": {
+                  "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 access key id.",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "bucket": {
+                  "description": "Bucket is the name Name of the bucket to store backups.",
+                  "type": "string"
+                },
+                "endpoint": {
+                  "description": "Endpoint is the S3 API endpoint without scheme.",
+                  "type": "string"
+                },
+                "prefix": {
+                  "description": "Prefix indicates a folder/subfolder in the bucket. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region is the S3 region name to use.",
+                  "type": "string"
+                },
+                "secretAccessKeySecretKeyRef": {
+                  "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 secret key.",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "sessionTokenSecretKeyRef": {
+                  "description": "SessionTokenSecretKeyRef is a reference to a Secret key containing the S3 session token.",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "ssec": {
+                  "description": "SSEC is a reference to a Secret containing the SSE-C (Server-Side Encryption with Customer-Provided Keys) key.\nThe secret must contain a 32-byte key (256 bits) in the specified key.\nThis enables server-side encryption where you provide and manage the encryption key.",
+                  "properties": {
+                    "customerKeySecretKeyRef": {
+                      "description": "CustomerKeySecretKeyRef is a reference to a Secret key containing the SSE-C customer-provided encryption key.\nThe key must be a 32-byte (256-bit) key encoded in base64.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "customerKeySecretKeyRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "TLS provides the configuration required to establish TLS connections with S3.",
+                  "properties": {
+                    "caSecretKeyRef": {
+                      "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enabled is a flag to enable TLS.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "bucket",
+                "endpoint"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "strictMode": {
+          "description": "StrictMode controls the behavior when a point-in-time restoration cannot reach the exact target time:\nWhen enabled: Returns an error and avoids replaying binary logs if target time is not reached.\nWhen disabled (default): Replays available binary logs until the last recoverable time. It logs logs an error if target time is not reached.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "physicalBackupRef",
+        "storage"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PointInTimeRecoveryStatus represents the current status of the point-in-time-recovery.",
+      "properties": {
+        "lastRecoverableTime": {
+          "description": "LastRecoverableTime is the most recent recoverable time based on the current state of physical backups and archived binary logs.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/k8s.mariadb.com/restore_v1alpha1.json
+++ b/k8s.mariadb.com/restore_v1alpha1.json
@@ -23,18 +23,18 @@
               "type": "boolean"
             },
             "nodeAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                     "properties": {
                       "preference": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -63,7 +63,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -110,15 +110,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                   "properties": {
                     "nodeSelectorTerms": {
                       "items": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -147,7 +147,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -193,21 +193,21 @@
               "additionalProperties": false
             },
             "podAntiAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                     "properties": {
                       "podAffinityTerm": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                         "properties": {
                           "labelSelector": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                             "properties": {
                               "matchExpressions": {
                                 "items": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                   "properties": {
                                     "key": {
                                       "type": "string"
@@ -271,14 +271,14 @@
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                     "properties": {
                       "labelSelector": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -367,7 +367,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -914,7 +914,7 @@
               "description": "Volume is a Kubernetes volume specification.",
               "properties": {
                 "csi": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
                   "properties": {
                     "driver": {
                       "type": "string"
@@ -923,7 +923,7 @@
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                       "properties": {
                         "name": {
                           "default": "",
@@ -950,7 +950,7 @@
                   "additionalProperties": false
                 },
                 "emptyDir": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
                   "properties": {
                     "medium": {
                       "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -973,7 +973,7 @@
                   "additionalProperties": false
                 },
                 "hostPath": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -989,7 +989,7 @@
                   "additionalProperties": false
                 },
                 "nfs": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
                   "properties": {
                     "path": {
                       "type": "string"
@@ -1009,7 +1009,7 @@
                   "additionalProperties": false
                 },
                 "persistentVolumeClaim": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
                   "properties": {
                     "claimName": {
                       "type": "string"
@@ -1073,7 +1073,7 @@
           "description": "Volume is a Kubernetes Volume object that contains a backup.",
           "properties": {
             "csi": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#csivolumesource-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#csivolumesource-v1-core.",
               "properties": {
                 "driver": {
                   "type": "string"
@@ -1082,7 +1082,7 @@
                   "type": "string"
                 },
                 "nodePublishSecretRef": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
                   "properties": {
                     "name": {
                       "default": "",
@@ -1109,7 +1109,7 @@
               "additionalProperties": false
             },
             "emptyDir": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#emptydirvolumesource-v1-core.",
               "properties": {
                 "medium": {
                   "description": "StorageMedium defines ways that storage can be allocated to a volume.",
@@ -1132,7 +1132,7 @@
               "additionalProperties": false
             },
             "hostPath": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#hostpathvolumesource-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathvolumesource-v1-core",
               "properties": {
                 "path": {
                   "type": "string"
@@ -1148,7 +1148,7 @@
               "additionalProperties": false
             },
             "nfs": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nfsvolumesource-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nfsvolumesource-v1-core.",
               "properties": {
                 "path": {
                   "type": "string"
@@ -1168,7 +1168,7 @@
               "additionalProperties": false
             },
             "persistentVolumeClaim": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimvolumesource-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#persistentvolumeclaimvolumesource-v1-core.",
               "properties": {
                 "claimName": {
                   "type": "string"

--- a/k8s.mariadb.com/sqljob_v1alpha1.json
+++ b/k8s.mariadb.com/sqljob_v1alpha1.json
@@ -23,18 +23,18 @@
               "type": "boolean"
             },
             "nodeAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaffinity-v1-core",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#preferredschedulingterm-v1-core",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#preferredschedulingterm-v1-core",
                     "properties": {
                       "preference": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -63,7 +63,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -110,15 +110,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselector-v1-core",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselector-v1-core",
                   "properties": {
                     "nodeSelectorTerms": {
                       "items": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorterm-v1-core",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorterm-v1-core",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -147,7 +147,7 @@
                           },
                           "matchFields": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeselectorrequirement-v1-core",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeselectorrequirement-v1-core",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -193,21 +193,21 @@
               "additionalProperties": false
             },
             "podAntiAffinity": {
-              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podantiaffinity-v1-core.",
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podantiaffinity-v1-core.",
               "properties": {
                 "preferredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#weightedpodaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#weightedpodaffinityterm-v1-core.",
                     "properties": {
                       "podAffinityTerm": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                         "properties": {
                           "labelSelector": {
-                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                             "properties": {
                               "matchExpressions": {
                                 "items": {
-                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                                   "properties": {
                                     "key": {
                                       "type": "string"
@@ -271,14 +271,14 @@
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
-                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podaffinityterm-v1-core.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#podaffinityterm-v1-core.",
                     "properties": {
                       "labelSelector": {
-                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselector-v1-meta",
                         "properties": {
                           "matchExpressions": {
                             "items": {
-                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselectorrequirement-v1-meta",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#labelselectorrequirement-v1-meta",
                               "properties": {
                                 "key": {
                                   "type": "string"
@@ -356,7 +356,7 @@
         "dependsOn": {
           "description": "DependsOn defines dependencies with other SqlJob objectecs.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",
@@ -377,7 +377,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
           "items": {
-            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#localobjectreference-v1-core.",
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#localobjectreference-v1-core.",
             "properties": {
               "name": {
                 "default": "",


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

Method: converted `config/crd/bases/k8s.mariadb.com_*.yaml` from https://github.com/mariadb-operator/mariadb-operator/tree/26.6.0 with the same transformation as `Utilities/openapi2jsonschema.py` (additionalProperties, int-or-string, indent 2). Output verified byte-identical against the existing 25.10.3 files before regenerating. Adds the new `PointInTimeRecovery` kind.
